### PR TITLE
47 parameter for token access level

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -65,6 +65,8 @@ jobs:
           ADO_PAT: ${{ secrets.ADO_PAT }}
           ADO_ORGANIZATION: ${{ secrets.ADO_ORGANIZATION }}
           ADO_PROJECT: ${{ secrets.ADO_PROJECT }}
+          ADO_PAT_FINEGRAINED: ${{ secrets.ADO_PAT_FINEGRAINED }}
+          ADO_PAT_READONLY: ${{ secrets.ADO_PAT_READONLY }}
 
       - name: Upload Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2.9.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-tests/out
+tests/out*
 coverage.xml
 myenv.ps1

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ expects a PAT with full access permissions. Alternately, you can
 use a PAT with only read permissions or fine-grained permissions
 with the `-TokenType` parameter. The fine-grained permissions expect
 read access to all scopes and read & manage for scope that do not
-have read-only access.
+have read-only access. Documentation on how to create the PATs can
+be found in the [docs/token-permissions.md](docs/token-permissions.md).
 
 #### Example: Run with full access token
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ Install-Module -Name PSRule.Rules.AzureDevOps -Scope CurrentUser
 Once you have both modules installed, you can run an export of
 your Azure DevOps project and run the rules on the exported data.
 The `-PAT` value needs to be an Azure DevOps Personal Access Token
-with sufficient permissions to read the project data.
+with sufficient permissions to read the project data. The default
+expects a PAT with full access permissions. Alternately, you can
+use a PAT with only read permissions or fine-grained permissions
+with the `-TokenType` parameter. The fine-grained permissions expect
+read access to all scopes and read & manage for scope that do not
+have read-only access.
 
 ```powershell
 Export-AzDevOpsRuleData `

--- a/README.md
+++ b/README.md
@@ -50,12 +50,28 @@ with the `-TokenType` parameter. The fine-grained permissions expect
 read access to all scopes and read & manage for scope that do not
 have read-only access.
 
+#### Example: Run with full access token
+
 ```powershell
 Export-AzDevOpsRuleData `
     -Organization "MyOrg" `
     -Project "MyProject" `
     -PAT $MyPAT `
     -OutputPath "C:\Temp\MyProject"
+Assert-PSRule `
+    -InputPath "C:\Temp\MyProject\" `
+    -Module PSRule.Rules.AzureDevOps
+```
+
+#### Example: Run with read-only access token
+
+```powershell
+Export-AzDevOpsRuleData `
+    -Organization "MyOrg" `
+    -Project "MyProject" `
+    -PAT $MyPAT `
+    -OutputPath "C:\Temp\MyProject" `
+    -TokenType ReadOnly
 Assert-PSRule `
     -InputPath "C:\Temp\MyProject\" `
     -Module PSRule.Rules.AzureDevOps

--- a/docs/token-permissions.md
+++ b/docs/token-permissions.md
@@ -1,0 +1,106 @@
+# PSRule.Rules.AzureDevOps Token Permissions
+
+## Details on how to configure token permissions
+
+PSRule.Rules.AzureDevOps requires a personal access token with the appropriate
+permissions to export data from Azure DevOps. When running PSRule.Rules.AzureDevOps
+you can choose 3 different token types:
+
+- **FullAccess**: Allows for full access to Azure DevOps, use with caution
+- **FineGrained**: Allows for fine-grained access to Azure DevOps, this is the recommended token type
+- **ReadOnly**: Allows for read-only access to Azure DevOps
+
+### FullAccess TokenType
+
+The `FullAccess` token type is the most permissive and allows for maximum rule
+coverage. This token type is recommended for use with PSRule.Rules.AzureDevOps
+but should be used with caution. Check your organization's security policies
+before using this token type.
+
+The FullAccess token type can be created in Azure DevOps by following these
+steps:
+
+1. Navigate to your Azure DevOps organization
+2. Select the **User Settings** option from the top right menu
+3. Select the **Personal access tokens** option from the menu
+4. Click the **New Token** button
+5. Enter a name for the token
+6. Select the **Full access** scope
+7. Click the **Create** button
+8. Copy the token value and store it in a secure location
+9. Use the token value in your pipeline
+
+### FineGrained TokenType
+
+The `FineGrained` token type is the recommended token type for use with
+PSRule.Rules.AzureDevOps. This token type allows for fine-grained access to
+Azure DevOps and is the most secure token type that allows for near-maximum
+rule coverage while still offering a detailed overview of the required permissions.
+
+The FineGrained token type can be created in Azure DevOps by following these
+steps:
+
+1. Navigate to your Azure DevOps organization
+2. Select the **User Settings** option from the top right menu
+3. Select the **Personal access tokens** option from the menu
+4. Click the **New Token** button
+5. Enter a name for the token
+6. Select the **Custom defined** scope
+7. Select `Read` for all scopes that have a `Read` option
+8. Select `Read & Manage` for all scopes that have a `Read & Manage` option
+9. Do not select any other scopes
+10. Click the **Create** button
+11. Copy the token value and store it in a secure location
+12. Use the token value in your pipeline
+
+### ReadOnly TokenType
+
+The `ReadOnly` token type is the most restrictive and allows for read-only access
+to Azure DevOps. This token type is recommended for use with PSRule.Rules.AzureDevOps
+when your security policies do not allow for the use of the `FullAccess` or `FineGrained`
+token types.
+
+The ReadOnly token type can be created in Azure DevOps by following these
+steps:
+
+1. Navigate to your Azure DevOps organization
+2. Select the **User Settings** option from the top right menu
+3. Select the **Personal access tokens** option from the menu
+4. Click the **New Token** button
+5. Enter a name for the token
+6. Select the **Custom defined** scope
+7. Select `Read` for all scopes that have a `Read` option
+8. Do not select any other scopes
+9. Click the **Create** button
+10. Copy the token value and store it in a secure location
+11. Use the token value in your pipeline
+
+## Token Scopes
+
+The following table lists the token scopes that are required for each command.
+
+| Rule Function                             | API(s)                                   | Version       | Method | Scope(s)                | PAT Category        | PAT Name        |
+|-------------------------------------------|------------------------------------------|---------------|--------|-------------------------|---------------------|-----------------|
+| Get-AzDevOpsProjects                      | projects                                 | 6.0           | GET    | vso.profile             | User Profile        | Read            |
+|                                           |                                          |               |        | vso.project             | Project and Team    | Read            |
+| Get-AzDevOpsPipelines                     | pipelines                                | 6.0-preview.1 | GET    | vso.build               | Build               | Read            |
+|                                           | pipelines/{pipelineid}                   | 6.0-preview.1 | GET    | vso.build               | Build               | Read            |
+| Get-AzDevOpsPipelineAcls                  | accesscontrollists/{securityid}          | 6.0           | GET    | vso.security_manage     | Security            | Manage          |
+| Get-AzDevOpsPipelineYaml                  | pipelines/{pipelineid}/runs              | 5.1-preview   | POST   | vso.build               | Build               | Read            |
+|                                           | pipelines/{pipelineid}                   | 7.1-preview.1 | GET    | vso.build               | Build               | Read            |
+|                                           | git/repositories/{repositoryid}/items    | 6.0           | GET    | vso.code                | Code                | Read            |
+| Get-AzDevOpsEnvironments                  | pipelines/environments                   | 6.0-preview.1 | GET    | vso.environment_manage  | Agent Pools         | Read and Manage |
+|                                           |                                          |               |        | vso.build               | Build               | Read            |
+|                                           | pipelines/checks/configurations          | 7.2-preview.1 | GET    | vso.build               | Build               | Read            |
+| Get-AzDevOpsReleaseDefinitions            | release/definitions                      | 7.2-preview.4 | GET    | vso.release             | Release             | Read            |
+| Get-AzDevOpsReleaseDefinitionAcls         | accesscontrollists/{securityid}          | 6.0           | GET    | vso.security_manage     | Security            | Manage          |
+| Get-AzDevOpsPipelinesSettings             | build/generalsettings                   | 7.1-preview.1 | GET    | vso.project          | Build                  | Read            |
+| Get-AzDevOpsRepos                         | git/repositories                         | 6.0           | GET    | vso.code                | Code                | Read            |
+| Get-AzDevOpsBranchPolicy                  | policy/configurations                    | 6.0           | GET    | vso.code                | Code                | Read            |
+| Get-AzDevOpsRepositoryPipelinePermissions | pipelines/pipelinePermissions/repository |               | GET    | vso.build               | Build               | Read            |
+| Get-AzDevOpsRepositoryAcls                | accesscontrollists/{securityid}          | 6.0           | GET    | vso.security_manage     | Security            | Manage          |
+| Test-AzDevOpsFileExists                   | git/repositories/{repositoryid}/items    | 6.0           | GET    | vso.code                | Code                | Read            |
+| Get-AzDevOpsRepositoryGhas                | Contribution/HierarchyQuery              | 5.0-preview.1 | POST   | tbc                     | tbc                 | FullACcess           |
+| Get-AzDevOpsArmServiceConnections         | serviceendpoint/endpoints                | 6.0-preview.4 | GET    | vso.serviceendpoint     | Service Connections | Read            |
+| Get-AzDevOpsArmServiceConnectionChecks    | bipelines/checks/configurations          | 7.2-preview.1 | GET    | vso.build               | Build               | Read            |
+| Get-AzDevOpsVariableGroups                | distributed task/variablegroups          | 7.2-preview.2 | GET    | vso.variablegroups_read | Variable Groups     | Read            |

--- a/docs/token-permissions.md
+++ b/docs/token-permissions.md
@@ -75,7 +75,7 @@ steps:
 10. Copy the token value and store it in a secure location
 11. Use the token value in your pipeline
 
-## Token Scopes
+## Token Scopes for module functions
 
 The following table lists the token scopes that are required for each command.
 
@@ -104,3 +104,55 @@ The following table lists the token scopes that are required for each command.
 | Get-AzDevOpsArmServiceConnections         | serviceendpoint/endpoints                | 6.0-preview.4 | GET    | vso.serviceendpoint     | Service Connections | Read            |
 | Get-AzDevOpsArmServiceConnectionChecks    | bipelines/checks/configurations          | 7.2-preview.1 | GET    | vso.build               | Build               | Read            |
 | Get-AzDevOpsVariableGroups                | distributed task/variablegroups          | 7.2-preview.2 | GET    | vso.variablegroups_read | Variable Groups     | Read            |
+
+## Token Scopes for rules
+
+The following table lists the token scopes that are required for each rule.
+
+| Rule | Minimum TokenType |
+|------|-------------------|
+|[Azure.DevOps.Pipelines.Core.UseYamlDefinition](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.UseYamlDefinition.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Core.InheritedPermissions](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.InheritedPermissions.md)|FineGrained|
+|[Azure.DevOps.Pipelines.Core.NoPlainTextSecrets](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.NoPlainTextSecrets.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Environments.Description](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.Description.md)|FineGrained|
+|[Azure.DevOps.Pipelines.Environments.ProductionBranchLimit](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionBranchLimit.md)|FineGrained|
+|[Azure.DevOps.Pipelines.Environments.ProductionCheckProtection](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionCheckProtection.md)|FineGrained|
+|[Azure.DevOps.Pipelines.Environments.ProductionHumanApproval](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionHumanApproval.md)|FineGrained|
+|[Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Releases.Definition.SelfApproval](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.SelfApproval.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions.md)|FineGrained|
+|[Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork.md)|ReadOnly|
+|[Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments.md)|ReadOnly|
+|[Azure.DevOps.Repos.BranchPolicyAllowSelfApproval](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyAllowSelfApproval.md)|ReadOnly|
+|[Azure.DevOps.Repos.BranchPolicyCommentResolution](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyCommentResolution.md)|ReadOnly|
+|[Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems.md)|ReadOnly|
+|[Azure.DevOps.Repos.BranchPolicyIsEnabled](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyIsEnabled.md)|ReadOnly|
+|[Azure.DevOps.Repos.BranchPolicyMergeStrategy](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyMergeStrategy.md)|ReadOnly|
+|[Azure.DevOps.Repos.BranchPolicyMinimumReviewers](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyMinimumReviewers.md)|ReadOnly|
+|[Azure.DevOps.Repos.BranchPolicyRequireBuild](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyRequireBuild.md)|ReadOnly|
+|[Azure.DevOps.Repos.BranchPolicyResetVotes](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyResetVotes.md)|ReadOnly|
+|[Azure.DevOps.Repos.HasBranchPolicy](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.HasBranchPolicy.md)|ReadOnly|
+|[Azure.DevOps.Repos.License](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.License.md)|ReadOnly|
+|[Azure.DevOps.Repos.Readme](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.Readme.md)|ReadOnly|
+|[Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled.md)|FullAccess|
+|[Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes.md)|FullAccess|
+|[Azure.DevOps.Repos.InheritedPermissions](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.InheritedPermissions.md)|FineGrained|
+|[Azure.DevOps.ServiceConnections.ClassicAzure](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ClassicAzure.md)|ReadOnly|
+|[Azure.DevOps.ServiceConnections.Description](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.Description.md)|ReadOnly|
+|[Azure.DevOps.ServiceConnections.GitHubPAT](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.GitHubPAT.md)|ReadOnly|
+|[Azure.DevOps.ServiceConnections.ProductionBranchLimit](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionBranchLimit.md)|ReadOnly|
+|[Azure.DevOps.ServiceConnections.ProductionCheckProtection](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionCheckProtection.md)|ReadOnly|
+|[Azure.DevOps.ServiceConnections.ProductionHumanApproval](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionHumanApproval.md)|ReadOnly|
+|[Azure.DevOps.ServiceConnections.Scope](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.Scope.md)|ReadOnly|
+|[Azure.DevOps.ServiceConnections.WorkloadIdentityFederation](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.WorkloadIdentityFederation.md)|ReadOnly|
+|[Azure.DevOps.Tasks.VariableGroup.Description](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.Description.md)|ReadOnly|
+|[Azure.DevOps.Tasks.VariableGroup.NoKeyVaultNoSecrets](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.NoKeyVaultNoSecrets.md)|ReadOnly|
+|[Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets](src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets.md)|ReadOnly|

--- a/src/PSRule.Rules.AzureDevOps/Functions/Common.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/Common.ps1
@@ -51,10 +51,16 @@ function Get-AzDevOpsProjects {
     [CmdletBinding()]
     [OutputType([System.Object[]])]
     param (
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+
+        [Parameter(ParameterSetName = 'PAT')]
         [string]
         $Organization
     )

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Environments.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Environments.ps1
@@ -8,6 +8,9 @@
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -20,32 +23,42 @@
 function Get-AzDevOpsEnvironments {
     [CmdletBinding()]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project
     )
-    $header = Get-AzDevOpsHeader -PAT $PAT
-    Write-Verbose "Getting environments for project $Project"
-    $uri = "https://dev.azure.com/$Organization/$Project/_apis/pipelines/environments?api-version=6.0-preview.1"
-    Write-Verbose "URI: $uri"
-    try {
-        $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $header
-        # If the response is a string and not an object, throw an exception for authentication failure or project not found
-        if ($response -is [string]) {
-            throw "Authentication failed or project not found"
+    # If token type is ReadOnly, write a warning and exit the function returing null
+    if($TokenType -eq 'ReadOnly') {
+        Write-Warning "Token type ReadOnly does not have access to Azure DevOps Pipelines Environments"
+        return $null
+    } else {
+        $header = Get-AzDevOpsHeader -PAT $PAT
+        Write-Verbose "Getting environments for project $Project"
+        $uri = "https://dev.azure.com/$Organization/$Project/_apis/pipelines/environments?api-version=6.0-preview.1"
+        Write-Verbose "URI: $uri"
+        try {
+            $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $header
+            # If the response is a string and not an object, throw an exception for authentication failure or project not found
+            if ($response -is [string]) {
+                throw "Authentication failed or project not found"
+            }
         }
+        catch {
+            throw $_.Exception.Message
+        }
+        $environments = $response.value
+        return $environments
     }
-    catch {
-        throw $_.Exception.Message
-    }
-    $environments = $response.value
-    return $environments
 }
 Export-ModuleMember -Function Get-AzDevOpsEnvironments
 
@@ -59,6 +72,9 @@ Export-ModuleMember -Function Get-AzDevOpsEnvironments
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+    
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -78,43 +94,53 @@ Export-ModuleMember -Function Get-AzDevOpsEnvironments
     https://learn.microsoft.com/en-us/rest/api/azure/devops/approvalsandchecks/check-configurations/list?view=azure-devops-rest-7.2&tabs=HTTP
 #>
 function Get-AzDevOpsEnvironmentChecks {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Environment
     )
-    $header = Get-AzDevOpsHeader -PAT $PAT
-    Write-Verbose "Getting checks for environment $Environment"
-    $uri = "https://dev.azure.com/$Organization/$Project/_apis/pipelines/checks/configurations?api-version=7.2-preview.1&resourceType=environment&resourceId=$($Environment)&`$expand=settings"
-    Write-Verbose "URI: $uri"
-    try {
-        $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $header
-        # If the response is a string and not an object, throw an exception for authentication failure or project not found
-        if ($response -is [string]) {
-            throw "Authentication failed or project not found"
+    # If token type is ReadOnly, write a warning and exit the function returing null
+    if($TokenType -eq 'ReadOnly') {
+        Write-Warning "Token type ReadOnly does not have access to Azure DevOps Pipelines Environments"
+        return $null
+    } else {
+        $header = Get-AzDevOpsHeader -PAT $PAT
+        Write-Verbose "Getting checks for environment $Environment"
+        $uri = "https://dev.azure.com/$Organization/$Project/_apis/pipelines/checks/configurations?api-version=7.2-preview.1&resourceType=environment&resourceId=$($Environment)&`$expand=settings"
+        Write-Verbose "URI: $uri"
+        try {
+            $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $header
+            # If the response is a string and not an object, throw an exception for authentication failure or project not found
+            if ($response -is [string]) {
+                throw "Authentication failed or project not found"
+            }
         }
+        catch {
+            throw $_.Exception.Message
+        }
+        $checks = $response.value
+        if($null -eq $checks) {
+            return @()
+            # Else if $checks is not an array, but a single object
+        } elseif ($null -eq $checks.Count -or $checks.Count -eq 0) {
+            return @($checks)
+        }
+        return $checks
     }
-    catch {
-        throw $_.Exception.Message
-    }
-    $checks = $response.value
-    if($null -eq $checks) {
-        return @()
-        # Else if $checks is not an array, but a single object
-    } elseif ($null -eq $checks.Count -or $checks.Count -eq 0) {
-        return @($checks)
-    }
-    return $checks
 }
 Export-ModuleMember -Function Get-AzDevOpsEnvironmentChecks
 <#
@@ -127,6 +153,9 @@ Export-ModuleMember -Function Get-AzDevOpsEnvironmentChecks
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -137,34 +166,44 @@ Export-ModuleMember -Function Get-AzDevOpsEnvironmentChecks
     Export-AzDevOpsEnvironmentChecks -PAT $PAT -Organization $Organization -Project $Project
 #>
 function Export-AzDevOpsEnvironmentChecks {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     [OutputType([System.Object[]])]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $OutputPath
 
     )
-    $environments = Get-AzDevOpsEnvironments -PAT $PAT -Organization $Organization -Project $Project
-    $environments | ForEach-Object {
-        if($null -ne $_) {
-            $environment = $_
-            # Add a ObjectType indicator for Azure.DevOps.Pipelines.Environment
-            $environment | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.Pipelines.Environment'
-            $checks = @(Get-AzDevOpsEnvironmentChecks -PAT $PAT -Organization $Organization -Project $Project -Environment $environment.id)
-            $environment | Add-Member -MemberType NoteProperty -Name checks -Value $checks
-            Write-Verbose "Exporting environment $($environment.name) to JSON"
-            Write-Verbose "Output file: $OutputPath\$($environment.name).ado.env.json"
-            $environment | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\$($environment.name).ado.env.json"
+    # If token type is ReadOnly, write a warning and exit the function returing null
+    if($TokenType -eq 'ReadOnly') {
+        Write-Warning "Token type ReadOnly does not have access to Azure DevOps Pipelines Environments"
+        return $null
+    } else {
+        $environments = Get-AzDevOpsEnvironments -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project
+        $environments | ForEach-Object {
+            if($null -ne $_) {
+                $environment = $_
+                # Add a ObjectType indicator for Azure.DevOps.Pipelines.Environment
+                $environment | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.Pipelines.Environment'
+                $checks = @(Get-AzDevOpsEnvironmentChecks -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -Environment $environment.id)
+                $environment | Add-Member -MemberType NoteProperty -Name checks -Value $checks
+                Write-Verbose "Exporting environment $($environment.name) to JSON"
+                Write-Verbose "Output file: $OutputPath\$($environment.name).ado.env.json"
+                $environment | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\$($environment.name).ado.env.json"
+            }
         }
     }
 }

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Releases.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Releases.ps1
@@ -14,19 +14,27 @@
     .PARAMETER PAT
     A personal access token (PAT) used to authenticate with Azure DevOps.
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .EXAMPLE
     Get-AzDevOpsReleaseDefinitions -Organization 'contoso' -Project 'myproject' -PAT $MyPAT
 #>
 Function Get-AzDevOpsReleaseDefinitions {
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     Param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]
+        $PAT,
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]$Organization,
 
-        [Parameter(Mandatory = $true)]
-        [string]$Project,
-
-        [Parameter(Mandatory = $true)]
-        [string]$PAT
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]$Project
     )
     Write-Verbose "Getting release definitions for project $Project"
     $uri = "https://vsrm.dev.azure.com/$Organization/$Project/_apis/release/definitions?api-version=7.2-preview.4"
@@ -67,6 +75,9 @@ Export-ModuleMember -Function Get-AzDevOpsReleaseDefinitions
     .PARAMETER PAT
     A personal access token (PAT) used to authenticate with Azure DevOps.
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Folder
     The folder where the release definition is located.
 
@@ -74,43 +85,55 @@ Export-ModuleMember -Function Get-AzDevOpsReleaseDefinitions
     Get-AzDevOpsReleaseDefinitionAcls -Organization 'contoso' -ProjectId '12345678-1234-1234-1234-123456789012' -ReleaseDefinitionId 1 -PAT $MyPAT -Folder 'myfolder'
 #>
 Function Get-AzDevOpsReleaseDefinitionAcls {
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     Param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]
+        $PAT,
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+    
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]$Organization,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]$ProjectId,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [int]$ReleaseDefinitionId,
 
-        [Parameter(Mandatory = $true)]
-        [string]$PAT,
-
-        [Parameter(Mandatory = $false)]
+        [Parameter(ParameterSetName = 'PAT')]
         [string]$Folder = ''
     )
-    Write-Verbose "Getting release definition ACLs for release definition $ReleaseDefinitionId"
-    if ($Folder -eq '') {
-        $uri = "https://dev.azure.com/{0}/_apis/accesscontrollists/c788c23e-1b46-4162-8f5e-d7585343b5de?api-version=6.0&token={1}/{2}" -f $Organization, $ProjectId, $ReleaseDefinitionId
-    }
-    else {
-        $uri = "https://dev.azure.com/{0}/_apis/accesscontrollists/c788c23e-1b46-4162-8f5e-d7585343b5de?api-version=6.0&token={1}/{2}/{3}" -f $Organization, $ProjectId, $Folder, $ReleaseDefinitionId
-    }
-    Write-Verbose "URI: $uri"
-    $header = Get-AzDevOpsHeader -PAT $PAT
-    # try to get the release definition ACLs, throw a descriptive error if it fails for authentication or other reasons
-    try {
-        $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $header
-        # If the response is not an object but a string, the authentication failed
-        if ($response -is [string]) {
-            throw "Authentication failed or project not found"
+    # IF token type is ReadOnly, write a warning and exit the function returing null
+    if ($TokenType -eq 'ReadOnly') {
+        Write-Warning "The ReadOnly token type is not supported for this function"
+        return $null
+    } else {
+        Write-Verbose "Getting release definition ACLs for release definition $ReleaseDefinitionId"
+        if ($Folder -eq '') {
+            $uri = "https://dev.azure.com/{0}/_apis/accesscontrollists/c788c23e-1b46-4162-8f5e-d7585343b5de?api-version=6.0&token={1}/{2}" -f $Organization, $ProjectId, $ReleaseDefinitionId
         }
+        else {
+            $uri = "https://dev.azure.com/{0}/_apis/accesscontrollists/c788c23e-1b46-4162-8f5e-d7585343b5de?api-version=6.0&token={1}/{2}/{3}" -f $Organization, $ProjectId, $Folder, $ReleaseDefinitionId
+        }
+        Write-Verbose "URI: $uri"
+        $header = Get-AzDevOpsHeader -PAT $PAT
+        # try to get the release definition ACLs, throw a descriptive error if it fails for authentication or other reasons
+        try {
+            $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $header
+            # If the response is not an object but a string, the authentication failed
+            if ($response -is [string]) {
+                throw "Authentication failed or project not found"
+            }
+        }
+        catch {
+            throw $_.Exception.Message
+        }
+        return $response.value
     }
-    catch {
-        throw $_.Exception.Message
-    }
-    return $response.value
 }
 Export-ModuleMember -Function Get-AzDevOpsReleaseDefinitionAcls
 # End of function Get-AzDevOpsReleaseDefinitionAcls
@@ -131,6 +154,9 @@ Export-ModuleMember -Function Get-AzDevOpsReleaseDefinitionAcls
     .PARAMETER PAT
     A personal access token (PAT) used to authenticate with Azure DevOps.
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER OutputPath
     The path to the directory where the JSON files will be exported.
 
@@ -138,20 +164,29 @@ Export-ModuleMember -Function Get-AzDevOpsReleaseDefinitionAcls
     Export-AzDevOpsReleaseDefinitions -Organization 'contoso' -Project 'myproject' -PAT $MyPAT -OutputPath 'C:\temp'
 #>
 Function Export-AzDevOpsReleaseDefinitions {
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     Param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]
+        $PAT,
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+    
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]$Organization,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]$Project,
 
-        [Parameter(Mandatory = $true)]
-        [string]$PAT,
-
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]$OutputPath
     )
-    $definitions = Get-AzDevOpsReleaseDefinitions -Organization $Organization -Project $Project -PAT $PAT
+    # If ParameterSet is PAT, get all release definitions for the project
+    If ($PSCmdlet.ParameterSetName -eq 'PAT') {
+        $definitions = Get-AzDevOpsReleaseDefinitions -Organization $Organization -Project $Project -PAT $PAT -TokenType $TokenType
+    }
     foreach ($definition in $definitions) {
         if ($null -ne $definition.id) {
             $definitionId = $definition.id
@@ -180,10 +215,15 @@ Function Export-AzDevOpsReleaseDefinitions {
             else {
                 $folder = $response.path.replace('\','/')
             }
-            # Get the release definition ACLs
-            $acls = Get-AzDevOpsReleaseDefinitionAcls -Organization $Organization -ProjectId $projectId -ReleaseDefinitionId $definitionId -PAT $PAT -Folder $folder
-            # Add the ACLs to the response
-            $response | Add-Member -MemberType NoteProperty -Name 'Acls' -Value $acls
+            # If the token type is not ReadOnly, get the release definitions ACLs
+            if ($TokenType -ne 'ReadOnly') {
+                # Get the release definition ACLs
+                $acls = Get-AzDevOpsReleaseDefinitionAcls -Organization $Organization -ProjectId $projectId -ReleaseDefinitionId $definitionId -PAT $PAT -Folder $folder
+                # Add the ACLs to the response
+                $response | Add-Member -MemberType NoteProperty -Name 'Acls' -Value $acls
+            } else {
+                Write-Warning "The ReadOnly token type is not supported for ACL export"
+            }
             $response | ConvertTo-Json -Depth 100 | Out-File -FilePath $definitionPath
         }
     }

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Settings.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Settings.ps1
@@ -8,6 +8,9 @@
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -18,15 +21,19 @@
     Get-AzDevOpsPipelinesSettings -PAT $PAT -Organization $Organization -ProjectId $ProjectId
 #>
 Function Get-AzDevOpsPipelinesSettings {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project
     )
@@ -58,6 +65,9 @@ Export-ModuleMember -Function Get-AzDevOpsPipelinesSettings
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -71,18 +81,22 @@ Export-ModuleMember -Function Get-AzDevOpsPipelinesSettings
     Export-AzDevOpsPipelinesSettings -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
 #>
 function Export-AzDevOpsPipelinesSettings {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $OutputPath
     )

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
@@ -8,6 +8,9 @@
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -18,16 +21,20 @@
     Get-AzDevOpsRepos -PAT $PAT -Organization $Organization -Project $Project
 #>
 Function Get-AzDevOpsRepos {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     [OutputType([System.Object[]])]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project
     )
@@ -60,6 +67,9 @@ Export-ModuleMember -Function Get-AzDevOpsRepos
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -79,22 +89,26 @@ Export-ModuleMember -Function Get-AzDevOpsRepos
     This function returns an empty object if no branch policy is found for the branch
 #>
 Function Get-AzDevOpsBranchPolicy {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     [OutputType([object[]])]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Repository,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Branch
     )
@@ -130,6 +144,9 @@ Export-ModuleMember -Function Get-AzDevOpsBranchPolicy
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -143,19 +160,23 @@ Export-ModuleMember -Function Get-AzDevOpsBranchPolicy
     Get-AzDevOpsRepositoryPipelinePermissions -PAT $PAT -Organization $Organization -ProjectId $ProjectId -RepositoryId $RepositoryId
 #>
 Function Get-AzDevOpsRepositoryPipelinePermissions {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     [OutputType([object[]])]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $ProjectId,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $RepositoryId
     )
@@ -186,6 +207,9 @@ Export-ModuleMember -Function Get-AzDevOpsRepositoryPipelinePermissions
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -199,36 +223,46 @@ Export-ModuleMember -Function Get-AzDevOpsRepositoryPipelinePermissions
     Get-AzDevOpsRepositoryAcls -PAT $PAT -Organization $Organization -ProjectId $ProjectId -RepositoryId $RepositoryId
 #>
 Function Get-AzDevOpsRepositoryAcls {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     [OutputType([object[]])]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $ProjectId,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $RepositoryId
     )
-    $header = Get-AzDevOpsHeader -PAT $PAT
-    $uri = "https://dev.azure.com/{0}/_apis/accesscontrollists/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87?api-version=6.0" -f $Organization
-    try {
-        $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $header -ContentType "application/json"
-        # If the response is a string and not an object, throw an exception for authentication failure or project not found
-        if ($response -is [string]) {
-            throw "Authentication failed or project not found"
+    # If the token type is ReadOnly, write a warning and return null
+    if ($TokenType -eq "ReadOnly") {
+        Write-Warning "The ReadOnly token type does not have access to the Repositories ACLs API, returning null"
+        return $null
+    } else {
+        $header = Get-AzDevOpsHeader -PAT $PAT
+        $uri = "https://dev.azure.com/{0}/_apis/accesscontrollists/2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87?api-version=6.0" -f $Organization
+        try {
+            $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $header -ContentType "application/json"
+            # If the response is a string and not an object, throw an exception for authentication failure or project not found
+            if ($response -is [string]) {
+                throw "Authentication failed or project not found"
+            }
+            $thisRepoPerms = $response.value | where-object {($_.token -eq "repoV2/$($ProjectId)/$($RepositoryId)")}
         }
-        $thisRepoPerms = $response.value | where-object {($_.token -eq "repoV2/$($ProjectId)/$($RepositoryId)")}
+        catch {
+            throw $_.Exception.Message
+        }
+        return $thisRepoPerms
     }
-    catch {
-        throw $_.Exception.Message
-    }
-    return $thisRepoPerms
 }
 Export-ModuleMember -Function Get-AzDevOpsRepositoryAcls
 # End of Function Get-AzDevOpsRepositoryAcls
@@ -242,6 +276,9 @@ Export-ModuleMember -Function Get-AzDevOpsRepositoryAcls
 
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
+
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
 
     .PARAMETER Organization
     Organization name for Azure DevOps
@@ -262,22 +299,26 @@ Export-ModuleMember -Function Get-AzDevOpsRepositoryAcls
     This function return $true if the file exists and $false if it does not
 #>
 function Test-AzDevOpsFileExists {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     [OutputType([bool])]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Repository,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Path
     )
@@ -306,6 +347,9 @@ Export-ModuleMember -Function Test-AzDevOpsFileExists
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -319,47 +363,57 @@ Export-ModuleMember -Function Test-AzDevOpsFileExists
     Get-AzDevOpsRepositoryGhas -PAT $PAT -Organization $Organization -Project $Project -Repository $Repository
 #>
 Function Get-AzDevOpsRepositoryGhas {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     [OutputType([object])]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $ProjectId,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $RepositoryId
     )
-    $header = Get-AzDevOpsHeader -PAT $PAT
-    $payload = @{
-        contributionIds = @(
-            "ms.vss-features.my-organizations-data-provider"
-            "ms.vss-advsec.advanced-security-enablement-data-provider"
-        )
-        dataProviderContext = @{
-            properties = @{
-                givenProjectId = $ProjectId
-                givenRepoId = $RepositoryId
+    # token is not FullAccess, write a warning and return null
+    if ($TokenType -ne "FullAccess") {
+        Write-Warning "The $TokenType token type does not have access to the Repositories API, returning null"
+        return $null
+    } else {
+        $header = Get-AzDevOpsHeader -PAT $PAT
+        $payload = @{
+            contributionIds = @(
+                "ms.vss-features.my-organizations-data-provider"
+                "ms.vss-advsec.advanced-security-enablement-data-provider"
+            )
+            dataProviderContext = @{
+                properties = @{
+                    givenProjectId = $ProjectId
+                    givenRepoId = $RepositoryId
+                }
             }
         }
-    }
-    $url = "https://dev.azure.com/$Organization/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1"
-    try {
-        $response = Invoke-RestMethod -Uri $url -Method Post -Headers $header -Body ($payload | ConvertTo-Json) -ContentType "application/json"
-        # If the response is a string and not an object, throw an exception for authentication failure or project not found
-        if ($response -is [string]) {
-            throw "Authentication failed or project not found"
+        $url = "https://dev.azure.com/$Organization/_apis/Contribution/HierarchyQuery?api-version=5.0-preview.1"
+        try {
+            $response = Invoke-RestMethod -Uri $url -Method Post -Headers $header -Body ($payload | ConvertTo-Json) -ContentType "application/json"
+            # If the response is a string and not an object, throw an exception for authentication failure or project not found
+            if ($response -is [string]) {
+                throw "Authentication failed or project not found"
+            }
         }
+        catch {
+            throw $_.Exception.Message
+        }
+        return $response.dataProviders.'ms.vss-advsec.advanced-security-enablement-data-provider'
     }
-    catch {
-        throw $_.Exception.Message
-    }
-    return $response.dataProviders.'ms.vss-advsec.advanced-security-enablement-data-provider'
 }
 Export-ModuleMember -Function Get-AzDevOpsRepositoryGhas
 # End of Function Get-AzDevOpsRepositoryGhas
@@ -373,6 +427,9 @@ Export-ModuleMember -Function Get-AzDevOpsRepositoryGhas
 
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
+
+    .PARAMETER TokenType
+    Token Type for Azure DevOps, can be FullAccess, FineGrained or ReadOnly
 
     .PARAMETER Organization
     Organization name for Azure DevOps
@@ -390,51 +447,65 @@ Export-ModuleMember -Function Get-AzDevOpsRepositoryGhas
     This function returns an empty object if no branch policy is found for the branch
 #>
 function Export-AzDevOpsReposAndBranchPolicies {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $OutputPath
     )
-    # Get all repos in project
-    $repos = Get-AzDevOpsRepos -PAT $PAT -Organization $Organization -Project $Project
+    # If the parameter set is PAT, get the repositories
+    if ($PSCmdlet.ParameterSetName -eq 'PAT') {
+        $repos = Get-AzDevOpsRepos -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project
+    }
     $repos | ForEach-Object {
         if ($null -ne $_) {
             $repo = $_
             # Add ObjectType Azure.DevOps.Repo to repo object
             $repo | Add-Member -MemberType NoteProperty -Name ObjectType -Value "Azure.DevOps.Repo"
             Write-Verbose "Getting branch policy for repo $($repo.name)"
-            $branchPolicy = Get-AzDevOpsBranchPolicy -PAT $PAT -Organization $Organization -Project $Project -Repository $repo.id -Branch $repo.defaultBranch
+            If($repo.defaultBranch) {
+                $branchPolicy = Get-AzDevOpsBranchPolicy -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -Repository $repo.id -Branch $repo.defaultBranch
+            }
             $repo | Add-Member -MemberType NoteProperty -Name MainBranchPolicy -Value $branchPolicy
             # Add a property indicating if a file named README.md or README exists in the repo
-            $readmeExists = ((Test-AzDevOpsFileExists -PAT $PAT -Organization $Organization -Project $Project -Repository $repo.id -Path "README.md") -or (Test-AzDevOpsFileExists -PAT $PAT -Organization $Organization -Project $Project -Repository $repo.id -Path "README"))
+            $readmeExists = ((Test-AzDevOpsFileExists -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -Repository $repo.id -Path "README.md") -or (Test-AzDevOpsFileExists -PAT $PAT -Organization $Organization -Project $Project -Repository $repo.id -Path "README"))
             $repo | Add-Member -MemberType NoteProperty -Name ReadmeExists -Value $readmeExists
 
             # Add a property indicating if a file named LICENSE or LICENSE.md exists in the repo
-            $licenseExists = ((Test-AzDevOpsFileExists -PAT $PAT -Organization $Organization -Project $Project -Repository $repo.id -Path "LICENSE") -or (Test-AzDevOpsFileExists -PAT $PAT -Organization $Organization -Project $Project -Repository $repo.id -Path "LICENSE.md"))
+            $licenseExists = ((Test-AzDevOpsFileExists -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -Repository $repo.id -Path "LICENSE") -or (Test-AzDevOpsFileExists -PAT $PAT -Organization $Organization -Project $Project -Repository $repo.id -Path "LICENSE.md"))
             $repo | Add-Member -MemberType NoteProperty -Name LicenseExists -Value $licenseExists
 
-            # Add a property for GitHub Advanced Security (GHAS) data
-            $ghas = Get-AzDevOpsRepositoryGhas -PAT $PAT -Organization $Organization -ProjectId $repo.project.id -RepositoryId $repo.id
-            $repo | Add-Member -MemberType NoteProperty -Name Ghas -Value $ghas
-
+            # Add a property for GitHub Advanced Security (GHAS) data if the token type is FullAccess
+            if ($TokenType -eq "FullAccess") {
+                $ghas = Get-AzDevOpsRepositoryGhas -PAT $PAT -TokenType $TokenType -Organization $Organization -ProjectId $repo.project.id -RepositoryId $repo.id
+                $repo | Add-Member -MemberType NoteProperty -Name Ghas -Value $ghas
+            } else {
+                Write-Warning "The $TokenType token type does not have access to the GHAS API, returning null"
+            }
+            
             # Add a property with pipeline permissions
-            $pipelinePermissions = Get-AzDevOpsRepositoryPipelinePermissions -PAT $PAT -Organization $Organization -ProjectId $repo.project.id -RepositoryId $repo.id
+            $pipelinePermissions = Get-AzDevOpsRepositoryPipelinePermissions -PAT $PAT -TokenType $TokenType -Organization $Organization -ProjectId $repo.project.id -RepositoryId $repo.id
             $repo | Add-Member -MemberType NoteProperty -Name PipelinePermissions -Value $pipelinePermissions
 
-            # Add a property with repo ACLs
-            $repoAcls = Get-AzDevOpsRepositoryAcls -PAT $PAT -Organization $Organization -ProjectId $repo.project.id -RepositoryId $repo.id
-            $repo | Add-Member -MemberType NoteProperty -Name Acls -Value $repoAcls
-
+            # Add a property with repo ACLs if the token type is not ReadOnly
+            if ($TokenType -ne "ReadOnly") {
+                $repoAcls = Get-AzDevOpsRepositoryAcls -PAT $PAT -TokenType $TokenType -Organization $Organization -ProjectId $repo.project.id -RepositoryId $repo.id
+                $repo | Add-Member -MemberType NoteProperty -Name Acls -Value $repoAcls
+            }
+            
             # Export repo object to JSON file
             Write-Verbose "Exporting repo $($repo.name) to JSON as file $($repo.name).ado.repo.json"
             $repo | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\$($repo.name).ado.repo.json"

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
@@ -8,6 +8,9 @@
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token type for Azure DevOps (FullAccess, FineGrained, ReadOnly)
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -18,15 +21,19 @@
     Get-AzDevOpsServiceConnections -PAT $PAT -Organization $Organization -Project $Project
 #>
 function Get-AzDevOpsServiceConnections {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project
     )
@@ -59,6 +66,9 @@ Export-ModuleMember -Function Get-AzDevOpsServiceConnections
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token type for Azure DevOps (FullAccess, FineGrained, ReadOnly)
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -75,18 +85,22 @@ Export-ModuleMember -Function Get-AzDevOpsServiceConnections
     https://learn.microsoft.com/en-us/rest/api/azure/devops/approvalsandchecks/check-configurations/list?view=azure-devops-rest-7.2&tabs=HTTP
 #>
 function Get-AzDevOpsServiceConnectionChecks {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $ServiceConnectionId
     )
@@ -117,6 +131,9 @@ Export-ModuleMember -Function Get-AzDevOpsServiceConnectionChecks
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token type for Azure DevOps (FullAccess, FineGrained, ReadOnly)
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -133,18 +150,22 @@ Export-ModuleMember -Function Get-AzDevOpsServiceConnectionChecks
     https://learn.microsoft.com/en-us/rest/api/azure/devops/approvalsandchecks/check-configurations/list?view=azure-devops-rest-7.2&tabs=HTTP
 #>
 function Export-AzDevOpsServiceConnections {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $OutputPath
     )

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Tasks.VariableGroups.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Tasks.VariableGroups.ps1
@@ -14,19 +14,29 @@
     .PARAMETER PAT
     A personal access token (PAT) used to authenticate with Azure DevOps.
 
+    .PARAMETER TokenType
+    Token type for Azure DevOps (FullAccess, FineGrained, ReadOnly)
+
     .EXAMPLE
     Get-AzDevOpsVariableGroups -Organization 'myorganization' -Project 'myproject' -PAT $myPAT
 #>
 Function Get-AzDevOpsVariableGroups {
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]$Organization,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]$Project,
 
-        [Parameter(Mandatory = $true)]
-        [string]$PAT
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]
+        $PAT,
+
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess'
     )
     Write-Verbose "Getting variable groups for project $Project"
     $url = "https://dev.azure.com/$Organization/$Project/_apis/distributedtask/variablegroups?api-version=7.2-preview.2"
@@ -78,17 +88,26 @@ Export-ModuleMember -Function Get-AzDevOpsVariableGroups
 #>
 Function Export-AzDevOpsVariableGroups {
     param(
-        [Parameter(Mandatory = $true)]
-        [string]$Organization,
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]
+        $Organization,
 
-        [Parameter(Mandatory = $true)]
-        [string]$Project,
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]
+        $Project,
 
-        [Parameter(Mandatory = $true)]
-        [string]$PAT,
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]
+        $PAT,
 
-        [Parameter(Mandatory = $true)]
-        [string]$OutputPath
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
+        [string]
+        $OutputPath
     )
     $variableGroups = Get-AzDevOpsVariableGroups -Organization $Organization -Project $Project -PAT $PAT
     $variableGroups | ForEach-Object {

--- a/src/PSRule.Rules.AzureDevOps/PSRule.Rules.AzureDevOps.psd1
+++ b/src/PSRule.Rules.AzureDevOps/PSRule.Rules.AzureDevOps.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSRule.Rules.AzureDevOps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.12'
+ModuleVersion = '0.2.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core','Desktop')

--- a/src/PSRule.Rules.AzureDevOps/PSRule.Rules.AzureDevOps.psm1
+++ b/src/PSRule.Rules.AzureDevOps/PSRule.Rules.AzureDevOps.psm1
@@ -20,6 +20,9 @@ Get-ChildItem -Path "$PSScriptRoot/Functions/*.ps1" | ForEach-Object {
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token type for Azure DevOps (FullAccess, FineGrained, ReadOnly)
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 

--- a/src/PSRule.Rules.AzureDevOps/PSRule.Rules.AzureDevOps.psm1
+++ b/src/PSRule.Rules.AzureDevOps/PSRule.Rules.AzureDevOps.psm1
@@ -33,28 +33,32 @@ Get-ChildItem -Path "$PSScriptRoot/Functions/*.ps1" | ForEach-Object {
     Export-AzDevOpsRuleData -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
 #>
 Function Export-AzDevOpsRuleData {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Project,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $OutputPath
     )
-    Export-AzDevOpsReposAndBranchPolicies -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
-    Export-AzDevOpsEnvironmentChecks -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
-    Export-AzDevOpsServiceConnections -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
-    Export-AzDevOpsPipelines -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
-    Export-AzDevOpsPipelinesSettings -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
-    Export-AzDevOpsVariableGroups -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
-    Export-AzDevOpsReleaseDefinitions -PAT $PAT -Organization $Organization -Project $Project -OutputPath $OutputPath
+    Export-AzDevOpsReposAndBranchPolicies -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -OutputPath $OutputPath
+    Export-AzDevOpsEnvironmentChecks -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -OutputPath $OutputPath
+    Export-AzDevOpsServiceConnections -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -OutputPath $OutputPath
+    Export-AzDevOpsPipelines -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -OutputPath $OutputPath
+    Export-AzDevOpsPipelinesSettings -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -OutputPath $OutputPath
+    Export-AzDevOpsVariableGroups -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -OutputPath $OutputPath
+    Export-AzDevOpsReleaseDefinitions -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $Project -OutputPath $OutputPath
 }
 Export-ModuleMember -Function Export-AzDevOpsRuleData -Alias Export-AzDevOpsProjectRuleData
 # End of Function Export-AzDevOpsRuleData
@@ -69,6 +73,9 @@ Export-ModuleMember -Function Export-AzDevOpsRuleData -Alias Export-AzDevOpsProj
     .PARAMETER PAT
     Personal Access Token (PAT) for Azure DevOps
 
+    .PARAMETER TokenType
+    Token type for Azure DevOps (FullAccess, FineGrained, ReadOnly)
+
     .PARAMETER Organization
     Organization name for Azure DevOps
 
@@ -79,19 +86,23 @@ Export-ModuleMember -Function Export-AzDevOpsRuleData -Alias Export-AzDevOpsProj
     Export-AzDevOpsOrganizationRuleData -PAT $PAT -Organization $Organization -OutputPath $OutputPath
 #>
 Function Export-AzDevOpsOrganizationRuleData {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'PAT')]
     param (
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $PAT,
-        [Parameter()]
+        [Parameter(ParameterSetName = 'PAT')]
+        [ValidateSet('FullAccess', 'FineGrained', 'ReadOnly')]
+        [string]
+        $TokenType = 'FullAccess',
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $Organization,
-        [Parameter()]
+        [Parameter(Mandatory, ParameterSetName = 'PAT')]
         [string]
         $OutputPath
     )
-    $projects = Get-AzDevOpsProjects -PAT $PAT -Organization $Organization
+    $projects = Get-AzDevOpsProjects -PAT $PAT -TokenType $TokenType -Organization $Organization
     $projects | ForEach-Object {
         $project = $_
         # Create a subfolder for each project
@@ -99,7 +110,7 @@ Function Export-AzDevOpsOrganizationRuleData {
         if(!(Test-Path -Path $subPath)) {
             New-Item -Path $subPath -ItemType Directory
         }
-        Export-AzDevOpsRuleData -PAT $PAT -Organization $Organization -Project $project.name -OutputPath $subPath
+        Export-AzDevOpsRuleData -PAT $PAT -TokenType $TokenType -Organization $Organization -Project $project.name -OutputPath $subPath
     }
 }
 Export-ModuleMember -Function Export-AzDevOpsOrganizationRuleData

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.InheritedPermissions.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.InheritedPermissions.md
@@ -15,6 +15,8 @@ Pipeline permissions should not be inherited from the project.
 Pipeline permissions should not be inherited from the project. Inherited
 permissions can lead to unexpected access to resources.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Consider removing inherited permissions from the pipeline and setting

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.NoPlainTextSecrets.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.NoPlainTextSecrets.md
@@ -17,6 +17,8 @@ stored in Azure Key Vault and referenced in the variable group. This will preven
 secret from being exposed in the build logs. If the secret is stored in plain text, it
 will be exposed in the build logs.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider storing secrets in Azure Key Vault and referencing them in the variable group.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.UseYamlDefinition.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Core.UseYamlDefinition.md
@@ -18,6 +18,8 @@ you manage changes to your application code. You can use source control to view
 changes to your pipelines, roll back to previous versions, and easily collaborate
 with other developers on your team.
 
+Mininum TokenType: `ReadOnly
+
 ## RECOMMENDATION
 
 Use YAML pipeline definitions to define build and release pipelines.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.Description.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.Description.md
@@ -17,6 +17,8 @@ Adding a description to an environment will help users understand the purpose
 of the environment. This will help users understand how and when it should be
 used.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Consider adding a description to the environment.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionBranchLimit.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionBranchLimit.md
@@ -16,6 +16,8 @@ A production environment should be limited to the branches it can be used in. Th
 the environment is not used in a non-production branch. This rule checks if the
 environment is limited to a production branch.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Consider limiting the environment to a production branch.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionCheckProtection.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionCheckProtection.md
@@ -18,6 +18,8 @@ checks to prevent accidental changes to production resources. Checks can
 be used to require a user to approve a deployment or require a successful
 build before a deployment can be made.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Consider adding one or more checks to the environment.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionHumanApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Environments.ProductionHumanApproval.md
@@ -19,6 +19,8 @@ changes to production resources. For example, a service connection scoped to
 production should be protected with a check that requires a minimum number of
 reviewers or a specific CI pipeline must pass.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Consider protecting a service connection scoped to production with a human

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest.md
@@ -16,6 +16,8 @@ Microsoft Hosted agent pools should be pinned to a version. This ensures that
 the pipeline will not be impacted by changes to the agent pool and its
 operating system.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider pinning the agent pool to a specific version.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName.md
@@ -15,6 +15,8 @@ Pipeline steps should have a display name.
 Pipeline steps should have a display name. This ensures that the pipeline is
 easier to read and understand.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider adding a display name to all steps.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions.md
@@ -15,6 +15,8 @@ Release Pipeline permissions should not be inherited from the project.
 Release Pipeline permissions should not be inherited from the project. Inherited
 permissions can lead to unexpected access to resources.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Consider removing inherited permissions from the release pipeline and setting

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets.md
@@ -17,6 +17,8 @@ stored in Azure Key Vault and referenced in the variable group. This will preven
 secret from being exposed in the build logs. If the secret is stored in plain text, it
 will be exposed in the build logs.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider storing secrets in Azure Key Vault and referencing them in the variable group.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval.md
@@ -21,6 +21,8 @@ You can configure the minimum number of approvers for this rule by setting the
 `releaseMinimumProductionApproverCount` configuration value in PSRule. The default
 value is `1`.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider protecting a release stage environment scoped to production with a human

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.SelfApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Releases.Definition.SelfApproval.md
@@ -16,6 +16,8 @@ An environment scoped to production should not allow self approval. This
 rule checks if a release stage environment scoped to production has
 self approval enabled.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider disabling self approval for the environment.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope.md
@@ -16,6 +16,8 @@ Limiting the job authorization scope to the current project will prevent the job
 being able to access resources in other projects. This can help prevent accidental
 access to resources in other projects.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider limiting the job authorization scope to the current project in the project settings.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines.md
@@ -17,6 +17,8 @@ can be configured to use a different set of resources. Limiting the job authoriz
 scope to the current project will prevent the job from being able to access resources
 in other projects. This can help prevent accidental access to resources in other projects.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider limiting the job authorization scope for release pipelines to the current project in the project settings.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines.md
@@ -17,6 +17,8 @@ can be configured to use a different set of resources. Limiting the job authoriz
 scope to the current project will prevent the job from being able to access resources
 in other projects. This can help prevent accidental access to resources in other projects.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider limiting the job authorization scope for YAML pipelines to the current project in the project settings.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime.md
@@ -17,6 +17,8 @@ pipeline. This can be useful for testing or debugging. However, this can also be
 used to override variables that are used to control the behavior of the pipeline
 and may result in unexpected behavior.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider disabling the ability to set variables at queue time in the project settings.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork.md
@@ -14,6 +14,8 @@ Project settings should require a comment for pull requests from a fork.
 
 Before building a fork, a member of the project should review the changes and approve the pull request. This can help prevent malicious code from being introduced into the project.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider requiring a comment for pull requests from a fork in the project settings.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork.md
@@ -14,6 +14,8 @@ Project settings should restrict access to secrets for pull requests from a fork
 
 Secrets can be used to store sensitive information such as passwords and access tokens. Secrets can be used in pipelines to access resources such as Azure Key Vault. Secrets can be configured to be available to all pipelines or only to specific pipelines. Secrets can also be configured to be available to pull requests from forks. This can be useful for open source projects that accept contributions from the community. However, this can also be a security risk. A malicious user could create a pull request from a fork and access the secrets in the pipeline. This could allow the malicious user to access sensitive information such as passwords and access tokens.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider restricting access to secrets for pull requests from a fork in the project settings.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments.md
@@ -14,6 +14,8 @@ Project settings should enforce sanitization of shell task arguments to prevent 
 
 Shell tasks can be used to run arbitrary commands on the agent. If the arguments are not sanitized, it is possible for a malicious actor to inject additional commands into the arguments. This can lead to the execution of malicious code on the agent.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider enforcing sanitization of shell task arguments in the project settings.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyAllowSelfApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyAllowSelfApproval.md
@@ -16,6 +16,8 @@ The branch policy should not allow creators to approve their own changes.
 This will help ensure that the code in the default branch is of a high quality
 and that the team's Git workflow is followed.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider disabling the option to allow creators to approve their own changes.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyCommentResolution.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyCommentResolution.md
@@ -14,6 +14,8 @@ A policy should be configured to require comments for pull requests to be resolv
 
 Require comments for pull requests to be resolved to ensure that all comments are addressed. This helps to ensure that all comments are addressed and improves the quality of the pull request.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider enabling the policy to require comments for pull requests to be resolved.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems.md
@@ -14,6 +14,8 @@ A policy should be configured to require linked work items for pull requests.
 
 Require linked work items for pull requests to ensure that changes are associated with a work item. This helps to track changes and ensure that changes are associated with a work item and thus documented in some way.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider enabling the policy to require linked work items for pull requests.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyIsEnabled.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyIsEnabled.md
@@ -21,6 +21,8 @@ A branch policy can be enabled for the default branch of a repository. This
 will help ensure that the code in the default branch is of a high quality and
 that the team's Git workflow is followed.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Make sure that the branch policy is enabled for the default branch of your

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyMergeStrategy.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyMergeStrategy.md
@@ -14,6 +14,8 @@ A policy should be configured to define a merge strategy for pull requests.
 
 Define a merge strategy for pull requests to ensure that changes are merged in a consistent way. This helps to ensure that changes are merged in a consistent way and thus reduces the risk of merge conflicts.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider enabling the policy to define a merge strategy for pull requests.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyMinimumReviewers.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyMinimumReviewers.md
@@ -21,6 +21,7 @@ You can configure the minimum number of reviewers for this rule by setting the
 `branchMinimumApproverCount` configuration value in PSRule. The default
 value is `1`.
 
+Mininum TokenType: `ReadOnly`
 
 ## RECOMMENDATION
 

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyRequireBuild.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyRequireBuild.md
@@ -19,6 +19,8 @@ are validated before being merged into the default branch. This rule does not
 validate that the build or CI pipeline is configured correctly. It only validates
 that a build or CI pipeline is configured.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider enabling the branch policy to require a build or CI pipeline to pass

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyResetVotes.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.BranchPolicyResetVotes.md
@@ -19,6 +19,8 @@ votes, the policy should be configured to reset votes when changes are updated.
 This will help ensure that the code in the default branch is of a high quality
 and that the team's Git workflow is followed.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider configuring the branch policy to reset votes when changes are updated.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes.md
@@ -16,6 +16,8 @@ GitHub Advanced Security provides a suite of security features for Azure DevOps
 repositories. This rule checks if GitHub Advanced Security is configured to block
 pushes not meeting security requirements.
 
+Mininum TokenType: `FullAccess`
+
 ## RECOMMENDATION
 
 Consider configuring GitHub Advanced Security to block pushes not meeting security

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled.md
@@ -23,6 +23,8 @@ GitHub Advanced Security adds the following features:
 - Secret scanning repo scanning
 - Dependency scanning
 
+Mininum TokenType: `FullAccess`
+
 ## RECOMMENDATION
 
 Consider enabling GitHub Advanced Security for the repository.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.HasBranchPolicy.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.HasBranchPolicy.md
@@ -17,6 +17,8 @@ team's Git workflow. Branch policies can enforce your team's code quality and
 change management standards. They can also help your team find and fix bugs
 earlier in the development cycle.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider adding a branch policy to the default branch of your repository.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.InheritedPermissions.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.InheritedPermissions.md
@@ -15,6 +15,8 @@ Repository permissions should not be inherited from the project.
 Repository permissions should not be inherited from the project. Inherited
 permissions can lead to unexpected access to repositories and branches.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Consider removing inherited permissions from the repository and setting

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.License.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.License.md
@@ -17,6 +17,8 @@ Public repositories on Azure DevOps are often used to share open source software
 
 To license your project, create a LICENSE file in the repository root.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider creating a LICENSE file in the default branch to communicate how your

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.Readme.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.Readme.md
@@ -16,6 +16,8 @@ information.
 When someone visits the repository homepage the README.md in the default branch
 is automatically shown.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider creating a README.md file in repository default branch to provide

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ClassicAzure.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ClassicAzure.md
@@ -19,6 +19,8 @@ be scoped to a specific resource group or subscription. This means that any user
 access to the service connection can deploy to any resource group or subscription. Also
 the Classic Azure service connection type does not support modern ways of authentication.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider using a service connection type that can be scoped to a specific resource group

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.Description.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.Description.md
@@ -17,6 +17,8 @@ Adding a description to a service connection will help users understand the
 purpose of the service connection. This will help users understand how and when
 it should be used.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider adding a description to the service connection.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.GitHubPAT.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.GitHubPAT.md
@@ -19,6 +19,8 @@ linked to a personal account and cannot be traced back to the specific connectio
 Azure DevOps. This means any user with access to the service connection can impersonate
 the user who created the service connection.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider using an oauth-based service connection.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionBranchLimit.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionBranchLimit.md
@@ -18,6 +18,8 @@ in. This ensures that the service connection is not used in a non-production
 branch. This rule checks that the service connection is limited to a production
 branch.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider limiting the service connection to a production branch.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionCheckProtection.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionCheckProtection.md
@@ -18,6 +18,8 @@ accidental changes to production resources. For example, a service connection
 scoped to production should be protected with a check that requires a minimum
 number of reviewers or a specific CI pipeline must pass.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider protecting a service connection scoped to production with one or

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionHumanApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.ProductionHumanApproval.md
@@ -19,6 +19,8 @@ changes to production resources. For example, a service connection scoped to
 production should be protected with a check that requires a minimum number of
 reviewers or a specific CI pipeline must pass.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider protecting a service connection scoped to production with a human

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.Scope.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.Scope.md
@@ -21,6 +21,8 @@ or access is made to the production resources or beyond. Normally it is not
 desirable to have a service connection with access to all resource groups
 in a subscription.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider using a resource group scope for a service connection scoped to

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.WorkloadIdentityFederation.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.ServiceConnections.WorkloadIdentityFederation.md
@@ -17,6 +17,8 @@ managed by Azure Active Directory to authenticate to Azure services
 instead of using a service principal managed by Azure DevOps. This is
 more secure as the service principal is not stored in Azure DevOps.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider using Workload Identity Federation for your service connections.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.Description.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.Description.md
@@ -17,6 +17,8 @@ Adding a description to a variable group will help users understand the
 purpose of the variable group. This will help users understand how and when
 it should be used.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider adding a description to the variable group.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.NoKeyVaultNoSecrets.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.NoKeyVaultNoSecrets.md
@@ -14,6 +14,8 @@ A variable group should not contain any secrets when it is not linked to a key v
 
 A variable group should not contain any secrets when it is not linked to a key vault. This is because the secrets will be stored in plain text in the variable group and can be viewed by anyone with access to the variable group.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider removing any secrets from the variable group or replacing them with variables that are linked to a key vault.

--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets.md
@@ -17,6 +17,8 @@ Azure Key Vault and referenced in the variable group. This will prevent the secr
 being exposed in the build logs. If the secret is stored in plain text, it will be
 exposed in the build logs.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Consider storing secrets in Azure Key Vault and referencing them in the variable group.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Core.InheritedPermissions.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Core.InheritedPermissions.md
@@ -15,6 +15,8 @@ Pipeline permissies mogen niet worden geërfd van het project.
 Pipeline permissies mogen niet worden geërfd van het project. Geërfde
 permissies kunnen leiden tot onverwachte toegang tot resources.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Overweeg om geërfde permissies uit de pipeline te verwijderen en expliciet

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Core.NoPlainTextSecrets.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Core.NoPlainTextSecrets.md
@@ -17,6 +17,8 @@ worden opgeslagen in Azure Key Vault en worden gerefereerd in de variabele groep
 voorkomen dat het geheim wordt blootgesteld in de build logs. Als het geheim in platte
 tekst wordt opgeslagen, wordt het blootgesteld in de build logs.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om geheimen op te slaan in Azure Key Vault en ze te refereren in de variabele

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Core.UseYamlDefinition.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Core.UseYamlDefinition.md
@@ -19,6 +19,8 @@ Het gebruik van YAML pipeline-definities biedt een aantal voordelen ten opzichte
 - YAML pipeline-definities kunnen worden gecontroleerd op wijzigingen en
   worden goedgekeurd voordat ze worden geïmplementeerd.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om YAML pipeline-definities te gebruiken om build- en 

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Environments.Description.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Environments.Description.md
@@ -15,6 +15,8 @@ Een Azure DevOps Pipelines environment zou een beschrijving moeten hebben.
 Het toevoegen van een beschrijving aan een Azure DevOps Pipelines 
 environment kan helpen bij het begrijpen van de context van de environment.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Overweeg om een beschrijving toe te voegen aan de Azure DevOps Pipelines

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Environments.ProductionBranchLimit.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Environments.ProductionBranchLimit.md
@@ -16,6 +16,8 @@ Een productie environment moet beperkt zijn in de branches waarin deze kan worde
 niet-productiebranch. Deze regel controleert of de environment is beperkt tot een
 productiebranch.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Overweeg om de environment te beperken tot een productiebranch.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Environments.ProductionCheckProtection.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Environments.ProductionCheckProtection.md
@@ -21,6 +21,8 @@ kunnen worden gebruikt om te eisen dat een gebruiker een implementatie
 goedkeurt of dat er een succesvolle build moet zijn voordat een
 implementatie kan worden uitgevoerd.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Overweeg om een of meer controles toe te voegen aan de Azure DevOps

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Environments.ProductionHumanApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Environments.ProductionHumanApproval.md
@@ -20,6 +20,8 @@ te voorkomen dat er per ongeluk wijzigingen worden aangebracht in
 productiebronnen. Een goedkeuring kan worden gebruikt om te eisen dat een
 gebruiker een implementatie goedkeurt voordat deze kan worden uitgevoerd.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Overweeg om een menselijke goedkeuring toe te voegen aan de Azure DevOps

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest.md
@@ -16,6 +16,8 @@ Microsoft Hosted agent pools zouden vastgepind moeten worden op een versie. Dit
 zorgt ervoor dat de pipeline niet beïnvloed wordt door wijzigingen aan de agent
 pool en het besturingssysteem.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de agent pool vast te pinnen op een specifieke versie.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName.md
@@ -15,6 +15,8 @@ Pipeline stappen moeten een weergavenaam hebben.
 Pipeline stappen moeten een weergavenaam hebben. Dit zorgt ervoor dat de pipeline
 makkelijker te lezen en te begrijpen is.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een weergavenaam toe te voegen aan de stappen.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions.md
@@ -15,6 +15,8 @@ Release Pipeline permissies mogen niet worden overgenomen van het project.
 Release Pipeline permissies mogen niet worden overgenomen van het project. Geërfde
 permissies kunnen leiden tot onverwachte toegang tot resources.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Overweeg om geërfde permissies uit de release pipeline te verwijderen en expliciete

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets.md
@@ -17,6 +17,8 @@ worden opgeslagen in Azure Key Vault en worden gerefereerd in de variabele groep
 voorkomen dat het geheim wordt blootgesteld in de build logs. Als het geheim in platte
 tekst wordt opgeslagen, wordt het blootgesteld in de build logs.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om geheimen op te slaan in Azure Key Vault en ze te refereren in de variabele

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval.md
@@ -23,6 +23,8 @@ U kunt het vereiste aantal goedkeurders voor deze regel configureren door de
 `releaseMinimumProductionApproverCount` configuratiewaarde in PSRule in te
 stellen. De standaardwaarde is `1`.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een menselijke goedkeuring toe te voegen aan de Azure DevOps

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Releases.Definition.SelfApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Releases.Definition.SelfApproval.md
@@ -15,6 +15,8 @@ Een release stage die is beperkt tot productie mag geen zelfgoedkeuring toestaan
 Een release stage die is beperkt tot productie mag geen zelfgoedkeuring toestaan. Deze
 regel controleert of een release stage die is beperkt tot productie zelfgoedkeuring heeft ingeschakeld.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om zelfgoedkeuring voor de omgeving uit te schakelen.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope.md
@@ -14,6 +14,8 @@ De projectinstellingen moeten de machtigingsomvang van de taak beperken tot de h
 
 Het beperken van de machtigingsomvang van de taak tot het huidige project voorkomt dat de taak toegang krijgt tot resources in andere projecten. Dit kan helpen voorkomen dat er per ongeluk toegang wordt verkregen tot resources in andere projecten.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de machtigingsomvang van de taak voor release-pipelines te beperken tot het huidige project in de projectinstellingen.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines.md
@@ -18,6 +18,8 @@ machtigingsomvang van de taak te beperken tot het huidige project, kan de taak g
 toegang krijgen tot resources in andere projecten. Dit kan helpen voorkomen dat er per
 ongeluk toegang wordt verkregen tot resources in andere projecten.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de machtigingsomvang van de taak voor release-pipelines te beperken tot het huidige project in de projectinstellingen.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines.md
@@ -18,6 +18,8 @@ machtigingsomvang van de taak te beperken tot het huidige project, kan de taak g
 toegang krijgen tot resources in andere projecten. Dit kan helpen voorkomen dat er per
 ongeluk toegang wordt verkregen tot resources in andere projecten.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de machtigingsomvang van de taak voor release-pipelines te beperken tot het

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime.md
@@ -17,6 +17,8 @@ pipeline zijn gedefinieerd te overschrijven. Dit kan handig zijn voor testen of 
 Dit kan echter ook worden gebruikt om variabelen te overschrijven die worden gebruikt om
 het gedrag van de pipeline te regelen en kan resulteren in onverwacht gedrag.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om het instellen van variabelen bij het wachtrijen uit te schakelen in de

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork.md
@@ -16,6 +16,8 @@ Voordat een fork wordt gebouwd, moet een lid van het project de wijzigingen beki
 pull-aanvraag goedkeuren. Dit kan helpen voorkomen dat er kwaadaardige code in het project
 wordt geïntroduceerd.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een opmerking te vereisen voor pull-aanvragen van een fork in de

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork.md
@@ -24,6 +24,8 @@ pull-aanvraag van een fork maken en de geheimen in de pipeline openen. Dit kan d
 kwaadwillende gebruiker in staat stellen om gevoelige informatie zoals wachtwoorden en
 toegangstokens te openen.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de toegang tot geheimen voor pull-aanvragen van een fork te beperken in de

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments.md
@@ -17,6 +17,8 @@ Als de argumenten niet worden gesaneerd, is het mogelijk dat een kwaadwillende e
 opdrachten in de argumenten injecteert. Dit kan leiden tot de uitvoering van kwaadaardige
 code op de agent.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om het instellen van variabelen bij het wachtrijen uit te schakelen in de

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyAllowSelfApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyAllowSelfApproval.md
@@ -18,6 +18,8 @@ eigen wijzigingen goedkeurt. Dit zal helpen om ervoor te zorgen dat de code
 in de standaard branch van hoge kwaliteit is en dat de Git workflow van het
 team wordt gevolgd.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de optie om makers hun eigen wijzigingen te laten goedkeuren

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyCommentResolution.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyCommentResolution.md
@@ -18,6 +18,8 @@ zorgen dat alle opmerkingen worden aangepakt. Dit helpt om ervoor te zorgen
 dat alle opmerkingen worden aangepakt en verbetert de kwaliteit van de pull
 request.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de optie om opmerkingen voor pull requests op te lossen in te

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems.md
@@ -17,6 +17,8 @@ Het vereisen van gekoppelde work items voor pull requests helpt om
 wijzigingen bij te houden en ervoor te zorgen dat wijzigingen zijn gekoppeld
 aan een work item en dus op de een of andere manier zijn gedocumenteerd.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de optie om gekoppelde work items voor pull requests te

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyIsEnabled.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyIsEnabled.md
@@ -23,6 +23,8 @@ repository. Dit zal helpen om ervoor te zorgen dat de code in de standaard
 branch van hoge kwaliteit is en dat de Git workflow van het team wordt
 gevolgd.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Zorg ervoor dat de branch policy is ingeschakeld voor de standaard branch 

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyMergeStrategy.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyMergeStrategy.md
@@ -18,6 +18,8 @@ wijzigingen op een consistente manier worden samengevoegd. Dit helpt om
 ervoor te zorgen dat wijzigingen op een consistente manier worden
 samengevoegd en vermindert zo het risico op merge conflicten.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de optie om een merge strategie voor pull requests te definiëren

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyMinimumReviewers.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyMinimumReviewers.md
@@ -20,6 +20,8 @@ is en dat de Git workflow van het team wordt gevolgd.
 Je kunt het minimum aantal reviewers voor deze regel configureren door de
 `branchMinimumApproverCount` configuratiewaarde in PSRule in te stellen.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de optie om een minimum aantal reviewers voor een branch policy

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyRequireBuild.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyRequireBuild.md
@@ -20,6 +20,8 @@ worden samengevoegd in de standaardbranch. Deze regel valideert niet dat de buil
 of CI-pijplijn correct is geconfigureerd. Het valideert alleen dat een build of
 CI-pijplijn is geconfigureerd.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de branch policy in te schakelen om een build of CI-pijplijn te vereisen.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyResetVotes.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.BranchPolicyResetVotes.md
@@ -21,6 +21,8 @@ resetten wanneer wijzigingen worden bijgewerkt. Dit zal helpen om ervoor te
 zorgen dat de code in de standaard branch van hoge kwaliteit is en dat de
 Git workflow van het team wordt gevolgd.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de branch policy te configureren om stemmen te resetten wanneer

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes.md
@@ -17,6 +17,8 @@ GitHub Advanced Security biedt een reeks beveiligingsfuncties voor Azure DevOps
 repositories. Deze regel controleert of GitHub Advanced Security is geconfigureerd om
 pushes te blokkeren die niet voldoen aan de beveiligingseisen.
 
+Mininum TokenType: `FullAccess`
+
 ## RECOMMENDATION
 
 Overweeg om GitHub Advanced Security te configureren om pushes te blokkeren die niet

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled.md
@@ -24,6 +24,7 @@ GitHub Advanced Security voegt de volgende functies toe:
 - Secret scannen repo scannen
 - Afhankelijkheid scannen
 
+Mininum TokenType: `FullAccess`
 
 ## RECOMMENDATION
 

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.HasBranchPolicy.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.HasBranchPolicy.md
@@ -17,6 +17,8 @@ workflow van het team bepalen. Branch policies kunnen de codekwaliteit en
 de normen voor wijzigingsbeheer van uw team afdwingen. Ze kunnen uw team ook
 helpen om bugs eerder in de ontwikkelingscyclus te vinden en op te lossen.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een branch policy toe te voegen aan de standaard branch van uw

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.InheritedPermissions.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.InheritedPermissions.md
@@ -15,6 +15,8 @@ Repository permissies mogen niet worden geërfd van het project.
 Repository permissies mogen niet worden geërfd van het project. Geërfde
 permissies kunnen leiden tot onverwachte toegang tot repositories en branches.
 
+Mininum TokenType: `FineGrained`
+
 ## RECOMMENDATION
 
 Overweeg om geërfde permissies uit de repository te verwijderen en expliciet

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.License.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.License.md
@@ -20,6 +20,8 @@ source software te delen.
 Om je project te licenseren, maak je een LICENSE bestand in de repository
 root.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een LICENSE bestand in de repository root te maken.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.Readme.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Repos.Readme.md
@@ -17,6 +17,8 @@ Als je een repository maakt, moet je een README.md bestand maken om het
 project uit te leggen en informatie te verstrekken. Het README.md bestand
 wordt automatisch weergegeven op de repository homepage.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een README.md bestand in de repository root te maken.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.ClassicAzure.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.ClassicAzure.md
@@ -20,6 +20,8 @@ resourcegroep of abonnement. Dit betekent dat elke gebruiker met toegang tot de
 serviceverbinding kan implementeren naar elke resourcegroep of elk abonnement. Ook het
 klassieke Azure-serviceverbindingstype ondersteunt geen moderne manieren van authenticatie.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een serviceverbindingstype te gebruiken dat kan worden geschaald naar een

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.Description.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.Description.md
@@ -17,6 +17,8 @@ Het toevoegen van een beschrijving aan een service connection zal gebruikers
 helpen het doel van de service connection te begrijpen. Dit zal gebruikers
 helpen te begrijpen hoe en wanneer het moet worden gebruikt.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een beschrijving toe te voegen aan de service connection.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.GitHubPAT.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.GitHubPAT.md
@@ -20,6 +20,8 @@ getraceerd naar de specifieke verbinding vanuit Azure DevOps. Dit betekent dat e
 gebruiker met toegang tot de serviceverbinding zich kan voordoen als de gebruiker die de
 serviceverbinding heeft gemaakt.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg een oauth-gebaseerde serviceverbinding te gebruiken.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.ProductionBranchLimit.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.ProductionBranchLimit.md
@@ -16,6 +16,8 @@ Een productieserviceverbinding moet beperkt zijn in de branches waarin deze kan 
 niet-productiebranch. Deze regel controleert of de serviceverbinding is beperkt tot een
 productiebranch.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om de serviceverbinding te beperken tot een productiebranch.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.ProductionCheckProtection.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.ProductionCheckProtection.md
@@ -22,6 +22,8 @@ resources. Bijvoorbeeld, een service connection die is beperkt tot productie
 zou moeten worden beschermd met een check die een minimum aantal reviewers
 vereist of een specifieke CI pipeline moet doorlopen.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een service connection die is beperkt tot productie te

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.ProductionHumanApproval.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.ProductionHumanApproval.md
@@ -20,6 +20,8 @@ deze wordt gebruikt voor het wijzigen van resources in andere omgevingen.
 Bijvoorbeeld, een service connection die is beperkt tot productie zou moeten
 worden beschermd met een check die een minimum aantal reviewers vereist.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een service connection die is beperkt tot productie te

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.Scope.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.Scope.md
@@ -22,6 +22,8 @@ aangebracht in de productie resources of daarbuiten. Normaal gesproken is
 het niet wenselijk om een service connection te hebben met toegang tot alle
 resource groups in een abonnement.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een service connection die is beperkt tot productie te beperken

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.WorkloadIdentityFederation.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.ServiceConnections.WorkloadIdentityFederation.md
@@ -18,6 +18,8 @@ naar Azure services in plaats van een service principal beheerd door
 Azure DevOps. Dit is veiliger omdat de service principal niet wordt
 opgeslagen in Azure DevOps.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om Workload Identity Federation te gebruiken voor je service connections.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Tasks.VariableGroup.Description.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Tasks.VariableGroup.Description.md
@@ -17,6 +17,8 @@ Het toevoegen van een beschrijving aan een variabele groep zal gebruikers
 helpen het doel van de variabele groep te begrijpen. Dit zal gebruikers
 helpen te begrijpen hoe en wanneer het moet worden gebruikt.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om een beschrijving toe te voegen aan de variabele groep.

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Tasks.VariableGroup.NoKeyVaultNoSecrets.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Tasks.VariableGroup.NoKeyVaultNoSecrets.md
@@ -18,6 +18,8 @@ gekoppeld aan een key vault. Dit komt omdat de geheimen in platte tekst
 worden opgeslagen in de variabele groep en kunnen worden bekeken door
 iedereen met toegang tot de variabele groep.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om alle geheimen uit de variabele groep te verwijderen of te

--- a/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets.md
+++ b/src/PSRule.Rules.AzureDevOps/nl/Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets.md
@@ -17,6 +17,8 @@ worden opgeslagen in Azure Key Vault en worden gerefereerd in de variabele groep
 voorkomt dat het geheim wordt blootgesteld in de build logs. Als het geheim in platte
 tekst wordt opgeslagen, wordt het blootgesteld in de build logs.
 
+Mininum TokenType: `ReadOnly`
+
 ## RECOMMENDATION
 
 Overweeg om geheimen op te slaan in Azure Key Vault en ze te refereren in de variabele

--- a/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Pipelines.Core.Rule.ps1
+++ b/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Pipelines.Core.Rule.ps1
@@ -21,6 +21,7 @@ Rule 'Azure.DevOps.Pipelines.Core.InheritedPermissions' `
     -Ref 'ADO-PL-002' `
     -Type 'Azure.DevOps.Pipeline' `
     -Tag @{ release = 'GA'} `
+    -If { "Acls" -in $TargetObject.psobject.Properties.Name } `
     -Level Warning {
         # Description "Pipelines should not have inherited permissions"
         Reason "The pipeline is using inherited permissions"

--- a/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Pipelines.Releases.Rule.ps1
+++ b/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Pipelines.Releases.Rule.ps1
@@ -42,6 +42,7 @@ Rule 'Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions' `
     -Ref 'ADO-RD-003' `
     -Type 'Azure.DevOps.Pipelines.Releases.Definition' `
     -Tag @{ release = 'GA'} `
+    -If { "Acls" -in $TargetObject.psobject.Properties.Name } `
     -Level Error {
         # Description 'Release pipeline should not inherit permissions from the project.'
         Reason 'The release pipeline inherits permissions from the project.'

--- a/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Repos.Rule.ps1
+++ b/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Repos.Rule.ps1
@@ -142,6 +142,7 @@ Rule 'Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled' `
     -Ref 'ADO-RP-010' `
     -Type 'Azure.DevOps.Repo' `
     -Tag @{ release = 'GA'} `
+    -If { "Ghas" -in $TargetObject.psobject.Properties.Name } `
     -Level Warning {
         # Description 'GitHub Advanced Security should be enabled'
         Reason 'GitHub Advanced Security is not enabled'
@@ -156,6 +157,7 @@ Rule 'Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes' `
     -Ref 'ADO-RP-011' `
     -Type 'Azure.DevOps.Repo' `
     -Tag @{ release = 'GA'} `
+    -If { "Ghas" -in $TargetObject.psobject.Properties.Name } `
     -Level Warning {
         # Description 'GitHub Advanced Security should block pushes'
         Reason 'GitHub Advanced Security does not block pushes'
@@ -170,6 +172,7 @@ Rule 'Azure.DevOps.Repos.InheritedPermissions' `
     -Ref 'ADO-RP-012' `
     -Type 'Azure.DevOps.Repo' `
     -Tag @{ release = 'GA'} `
+    -If { "Acls" -in $TargetObject.psobject.Properties.Name } `
     -Level Warning {
         # Description 'Repository should not have inherited permissions'
         Reason 'Repository has inherited permissions'

--- a/tests/Rules.Tests.ps1
+++ b/tests/Rules.Tests.ps1
@@ -26,6 +26,22 @@ BeforeAll {
     Export-AzDevOpsRuleData -PAT $env:ADO_PAT -Project $env:ADO_PROJECT -Organization $env:ADO_ORGANIZATION -OutputPath $outPath
     $ruleResult = Invoke-PSRule -InputPath "$($outPath)/" -Module PSRule.Rules.AzureDevOps -Format Detect -Culture en
     $noExtraLicenseBaselineResult = Invoke-PSRule -InputPath "$($outPath)/" -Module PSRule.Rules.AzureDevOps -Format Detect -Culture en -Baseline Baseline.NoExtraLicense
+
+    # Create a temporary test output folder for tests with the ReadOnly TokenType
+    $outPathReadOnly = New-Item -Path (Join-Path -Path $here -ChildPath 'outReadOnly') -ItemType Directory -Force;
+    $outPathReadOnly = $outPathReadOnly.FullName;
+
+    # Export all Azure DevOps rule data for project 'psrule-fail-project' to ReadOnly output folder
+    Export-AzDevOpsRuleData -PAT $env:ADO_PAT_READONLY -TokenType ReadOnly -Project $env:ADO_PROJECT -Organization $env:ADO_ORGANIZATION -OutputPath $outPathReadOnly
+    $ruleResultReadOnly = Invoke-PSRule -InputPath "$($outPathReadOnly)/" -Module PSRule.Rules.AzureDevOps -Format Detect -Culture en
+
+    # Create a temporary test output folder for tests with the FineGrained TokenType
+    $outPathFineGrained = New-Item -Path (Join-Path -Path $here -ChildPath 'outFineGrained') -ItemType Directory -Force;
+    $outPathFineGrained = $outPathFineGrained.FullName;
+
+    # Export all Azure DevOps rule data for project 'psrule-fail-project' to FineGrained output folder
+    Export-AzDevOpsRuleData -PAT $env:ADO_PAT_FINEGRAINED -TokenType FineGrained -Project $env:ADO_PROJECT -Organization $env:ADO_ORGANIZATION -OutputPath $outPathFineGrained
+    $ruleResultFineGrained = Invoke-PSRule -InputPath "$($outPathFineGrained)/" -Module PSRule.Rules.AzureDevOps -Format Detect -Culture en
 }
 
 Describe 'AzureDevOps ' {
@@ -62,6 +78,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should have the same results with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.Description' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.Description' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should have the same results with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.Description' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.Description' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Tasks.VariableGroup.Description.md');
             $fileExists | Should -Be $true;
@@ -77,6 +113,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should have the same results with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should have the same results with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Tasks.VariableGroup.NoPlainTextSecrets' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -100,6 +156,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should have the same results with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest' -and $_.Outcome -eq 'Fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest' -and $_.Outcome -eq 'Pass' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should have the same results with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest' -and $_.Outcome -eq 'Fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest' -and $_.Outcome -eq 'Pass' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.PipelineYaml.AgentPoolVersionNotLatest.md');
             $fileExists | Should -Be $true;
@@ -115,6 +191,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName' -and $_.Outcome -eq 'Pass' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should have the same results with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName' -and $_.Outcome -eq 'Fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName' -and $_.Outcome -eq 'Pass' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should have the same results with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName' -and $_.Outcome -eq 'Fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.PipelineYaml.StepDisplayName' -and $_.Outcome -eq 'Pass' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -138,6 +234,24 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should not be in the output for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionCheckProtection' -and $_.TargetName -match 'fail' })
+            $ruleHits.Count | Should -Be 0;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionCheckProtection' -and $_.TargetName -match 'success' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should have the same result as default for FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionCheckProtection' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionCheckProtection' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.Environments.ProductionCheckProtection.md');
             $fileExists | Should -Be $true;
@@ -153,6 +267,24 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionHumanApproval' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should not be in the output for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionHumanApproval' -and $_.TargetName -match 'fail' })
+            $ruleHits.Count | Should -Be 0;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionHumanApproval' -and $_.TargetName -match 'success' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should have the same result as default for FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionHumanApproval' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionHumanApproval' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -176,6 +308,24 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should not be in the output for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.Description' -and $_.TargetName -match 'fail' })
+            $ruleHits.Count | Should -Be 0;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.Description' -and $_.TargetName -match 'success' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should have the same result as default for FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.Description' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.Description' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.Environments.Description.md');
             $fileExists | Should -Be $true;
@@ -195,6 +345,24 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should not be in the output for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionBranchLimit' -and $_.TargetName -match 'fail' })
+            $ruleHits.Count | Should -Be 0;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionBranchLimit' -and $_.TargetName -match 'success' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should have the same result as default for FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionBranchLimit' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Environments.ProductionBranchLimit' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.Environments.ProductionBranchLimit.md');
             $fileExists | Should -Be $true;
@@ -204,11 +372,32 @@ Describe 'AzureDevOps ' {
     Context 'Azure.DevOps.Pipelines.Core.UseYamlDefinition' {
         It 'Should fail for targets named fail' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.UseYamlDefinition' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
             $ruleHits.Count | Should -Be 2;
         }
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.UseYamlDefinition' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.UseYamlDefinition' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 2;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.UseYamlDefinition' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.UseYamlDefinition' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 2;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.UseYamlDefinition' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -222,11 +411,27 @@ Describe 'AzureDevOps ' {
     Context 'Azure.DevOps.Pipelines.Core.InheritedPermissions' {
         It 'Should fail for targets named fail' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.InheritedPermissions' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
             $ruleHits.Count | Should -Be 2;
         }
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.InheritedPermissions' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should not be present for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.InheritedPermissions' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.InheritedPermissions' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 2;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.InheritedPermissions' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -240,6 +445,19 @@ Describe 'AzureDevOps ' {
     Context 'Azure.DevOps.Pipelines.Core.NoPlainTextSecrets' {
         It 'Should fail for targets named fail' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.NoPlainTextSecrets' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.NoPlainTextSecrets' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Core.NoPlainTextSecrets' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
             $ruleHits.Count | Should -Be 1;
         }
 
@@ -252,6 +470,18 @@ Describe 'AzureDevOps ' {
     Context 'Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime' {
         It 'Should Pass' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitSetVariablesAtQueueTime' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -269,6 +499,18 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScope.md');
             $fileExists | Should -Be $true;
@@ -278,6 +520,18 @@ Describe 'AzureDevOps ' {
     Context 'Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines' {
         It 'Should Pass' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForReleasePipelines' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -295,6 +549,18 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.Settings.LimitJobAuthorizationScopeForYamlPipelines.md');
             $fileExists | Should -Be $true;
@@ -304,6 +570,18 @@ Describe 'AzureDevOps ' {
     Context 'Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork' {
         It 'Should Pass' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.RequireCommentForPullRequestFromFork' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -321,6 +599,18 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.Settings.RestrictSecretsForPullRequestFromFork.md');
             $fileExists | Should -Be $true;
@@ -330,6 +620,18 @@ Describe 'AzureDevOps ' {
     Context 'Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments' {
         It 'Should Pass' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Settings.SanitizeShellTaskArguments' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -353,6 +655,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval' -and $_.TargetName -match 'Success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval' -and $_.TargetName -match 'Success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.Releases.Definition.ProductionApproval.md');
             $fileExists | Should -Be $true;
@@ -368,6 +690,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.SelfApproval' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.SelfApproval' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.SelfApproval' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same for the FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.SelfApproval' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.SelfApproval' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -391,6 +733,21 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should not be present with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should be the same as default with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Pipelines.Releases.Definition.InheritedPermissions.md');
             $fileExists | Should -Be $true;
@@ -406,6 +763,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Pipelines.Releases.Definition.NoPlainTextSecrets' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -429,6 +806,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.HasBranchPolicy' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.HasBranchPolicy' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.HasBranchPolicy' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.HasBranchPolicy' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Repos.HasBranchPolicy.md');
             $fileExists | Should -Be $true;
@@ -444,6 +841,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyIsEnabled' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyIsEnabled' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyIsEnabled' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyIsEnabled' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyIsEnabled' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -467,6 +884,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMinimumReviewers' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMinimumReviewers' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMinimumReviewers' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMinimumReviewers' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Repos.BranchPolicyMinimumReviewers.md');
             $fileExists | Should -Be $true;
@@ -482,6 +919,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyAllowSelfApproval' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyAllowSelfApproval' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyAllowSelfApproval' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyAllowSelfApproval' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyAllowSelfApproval' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -505,6 +962,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyResetVotes' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyResetVotes' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyResetVotes' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyResetVotes' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Repos.BranchPolicyResetVotes.md');
             $fileExists | Should -Be $true;
@@ -520,6 +997,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.Readme' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.Readme' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.Readme' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.Readme' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.Readme' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -543,6 +1040,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.License' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.License' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.License' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.License' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have a markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Repos.License.md');
             $fileExists | Should -Be $true;
@@ -558,6 +1075,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyEnforceLinkedWorkItems' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -581,6 +1118,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyCommentResolution' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyCommentResolution' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyCommentResolution' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyCommentResolution' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have a markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Repos.BranchPolicyCommentResolution.md');
             $fileExists | Should -Be $true;
@@ -596,6 +1153,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMergeStrategy' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMergeStrategy' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMergeStrategy' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMergeStrategy' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyMergeStrategy' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -624,6 +1201,16 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 0;
         }
 
+        It 'Should not be present with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should not be present with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Repos.GitHubAdvancedSecurityEnabled.md');
             $fileExists | Should -Be $true;
@@ -648,6 +1235,16 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 0;
         }
 
+        It 'Should not be present with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should not be present with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Repos.GitHubAdvancedSecurityBlockPushes.md');
             $fileExists | Should -Be $true;
@@ -663,6 +1260,21 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.InheritedPermissions' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should not be present with the ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.InheritedPermissions' })
+            $ruleHits.Count | Should -Be 0;
+        }
+
+        It 'Should be the same as default with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.InheritedPermissions' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.InheritedPermissions' -and $_.TargetName -match 'success' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -686,6 +1298,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyRequireBuild' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyRequireBuild' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyRequireBuild' -and $_.TargetName -match 'fail' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.BranchPolicyRequireBuild' -and $_.TargetName -match 'success' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have a markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.Repos.BranchPolicyRequireBuild.md');
             $fileExists | Should -Be $true;
@@ -701,6 +1333,26 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Description' -and $_.TargetName -like '*success*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Description' -and $_.TargetName -like '*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 3;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Description' -and $_.TargetName -like '*success*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Description' -and $_.TargetName -like '*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 3;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Description' -and $_.TargetName -like '*success*' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -724,6 +1376,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Scope' -and $_.TargetName -like '*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Scope' -and $_.TargetName -like '*success*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Scope' -and $_.TargetName -like '*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.Scope' -and $_.TargetName -like '*success*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.ServiceConnections.Scope.md');
             $fileExists | Should -Be $true;
@@ -743,6 +1415,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 1;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.WorkloadIdentityFederation' -and $_.TargetName -like '*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.WorkloadIdentityFederation' -and $_.TargetName -like '*success*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.WorkloadIdentityFederation' -and $_.TargetName -like '*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.WorkloadIdentityFederation' -and $_.TargetName -like '*success*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
         It 'Should have an English markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.ServiceConnections.WorkloadIdentityFederation.md');
             $fileExists | Should -Be $true;
@@ -757,6 +1449,24 @@ Describe 'AzureDevOps ' {
 
         It 'Should pass for production targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -like '*success*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -like '*fail*' })
+            $ruleHits.Count | Should -Be 0;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -like '*success*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -like '*fail*' })
+            $ruleHits.Count | Should -Be 0;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -like '*success*' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
             $ruleHits.Count | Should -Be 1;
         }
@@ -780,6 +1490,26 @@ Describe 'AzureDevOps ' {
             $ruleHits.Count | Should -Be 2;
         }
 
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ClassicAzure' -and $_.TargetName -like '*Classic*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ClassicAzure' -and $_.TargetName -notlike '*Classic*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 2;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ClassicAzure' -and $_.TargetName -like '*Classic*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ClassicAzure' -and $_.TargetName -notlike '*Classic*' })
+            $ruleHits[0].Outcome | Should -Be 'Pass';
+            $ruleHits.Count | Should -Be 2;
+        }
+
         It 'Should have a markdown help file' {
             $fileExists = Test-Path -Path (Join-Path -Path $ourModule -ChildPath 'en/Azure.DevOps.ServiceConnections.ClassicAzure.md');
             $fileExists | Should -Be $true;
@@ -789,6 +1519,18 @@ Describe 'AzureDevOps ' {
     Context 'Azure.DevOps.ServiceConnections.GitHubPAT' {
         It 'Should fail for connections named fail' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.GitHubPAT' -and $_.TargetName -like '*GitHub*PAT*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a ReadOnly TokenType' {
+            $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.GitHubPAT' -and $_.TargetName -like '*GitHub*PAT*fail*' })
+            $ruleHits[0].Outcome | Should -Be 'Fail';
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It 'Should be the same with a FineGrained TokenType' {
+            $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.GitHubPAT' -and $_.TargetName -like '*GitHub*PAT*fail*' })
             $ruleHits[0].Outcome | Should -Be 'Fail';
             $ruleHits.Count | Should -Be 1;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This feature enable the user to specify to some degree the scope of the `PAT` used so the export can be run with a fine-grained or read-only token without error.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This PR resolves #47 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Enterprise users require fine-grained or read-only permissions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Pester tests have been updated for various tokens.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
