### PR TITLE
Fix #83 - remove selectors, add example supression groups

### DIFF
--- a/example/best-practice/SupressionGroups.Rule.yaml
+++ b/example/best-practice/SupressionGroups.Rule.yaml
@@ -1,0 +1,84 @@
+---
+# Synopsis: Only main, master, develop, and release branches should be protected
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: 'non-production-branches'
+spec:
+  expiresOn: null
+  rule:
+  - Azure.DevOps.Repos.Branch.BranchPolicyAllowSelfApproval
+  - Azure.DevOps.Repos.Branch.BranchPolicyCommentResolution
+  - Azure.DevOps.Repos.Branch.BranchPolicyEnforceLinkedWorkItems
+  - Azure.DevOps.Repos.Branch.BranchPolicyIsEnabled
+  - Azure.DevOps.Repos.Branch.BranchPolicyMergeStrategy
+  - Azure.DevOps.Repos.Branch.BranchPolicyMinimumReviewers
+  - Azure.DevOps.Repos.Branch.BranchPolicyRequireBuild
+  - Azure.DevOps.Repos.Branch.BranchPolicyResetVotes
+  - Azure.DevOps.Repos.Branch.HasBranchPolicy
+  if:
+    allOf:
+    - name: '.'
+      notContains:
+      - 'refs/heads/main'
+      - 'refs/heads/master'
+      - 'refs/heads/develop'
+      - 'refs/heads/release'
+    - field: 'ObjectType'
+      equals: 'Azure.DevOps.Repo.Branch'
+
+---
+# Synposis: Only accept and production environments and should be protected
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: 'non-production-environments'
+spec:
+  expiresOn: null
+  rule:
+  - Azure.DevOps.Pipelines.Environments.ProductionBranchLimit
+  - Azure.DevOps.Pipelines.Environments.ProductionCheckProtection
+  - Azure.DevOps.Pipelines.Environments.ProductionHumanApproval
+  if:
+    allOf:
+    - name: '.'
+      notContains:
+      - 'acc'
+      - 'accept'
+      - 'acceptance'
+      - 'live'
+      - 'pre'
+      - 'prd'
+      - 'prod'
+      - 'production'
+    - field: 'ObjectType'
+      in:
+      - 'Azure.DevOps.Pipelines.Environment'
+
+---
+# Synposis: Only accept and production service connections should be protected
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: 'non-production-service-connections'
+spec:
+  expiresOn: null
+  rule:
+  - Azure.DevOps.ServiceConnections.ProductionBranchLimit
+  - Azure.DevOps.ServiceConnections.ProductionCheckProtection
+  - Azure.DevOps.ServiceConnections.ProductionHumanApproval
+  if:
+    allOf:
+    - name: '.'
+      notContains:
+      - 'acc'
+      - 'accept'
+      - 'acceptance'
+      - 'live'
+      - 'pre'
+      - 'prd'
+      - 'prod'
+      - 'production'
+    - field: 'ObjectType'
+      in:
+      - 'Azure.DevOps.ServiceConnection'

--- a/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Pipelines.Environments.Rule.ps1
+++ b/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Pipelines.Environments.Rule.ps1
@@ -4,7 +4,6 @@
 Rule 'Azure.DevOps.Pipelines.Environments.ProductionCheckProtection' `
     -Ref 'ADO-E-001' `
     -Type 'Azure.DevOps.Pipelines.Environment' `
-    -With 'IsProduction' `
     -Tag @{ release = 'GA'} `
     -Level Warning {
         # Description: Production environment should be protected by one or more checks
@@ -22,7 +21,6 @@ Rule 'Azure.DevOps.Pipelines.Environments.ProductionCheckProtection' `
 Rule 'Azure.DevOps.Pipelines.Environments.ProductionHumanApproval' `
     -Ref 'ADO-E-002' `
     -Type 'Azure.DevOps.Pipelines.Environment' `
-    -With 'IsProduction' `
     -Tag @{ release = 'GA'} `
     -Level Warning {
         # Description 'Production environment should be protected by a human approval'
@@ -51,7 +49,6 @@ Rule 'Azure.DevOps.Pipelines.Environments.Description' `
 Rule 'Azure.DevOps.Pipelines.Environments.ProductionBranchLimit' `
     -Ref 'ADO-E-004' `
     -Type 'Azure.DevOps.Pipelines.Environment' `
-    -With 'IsProduction' `
     -Tag @{ release = 'GA'} `
     -Level Warning {
         # Description 'Production environment should be limited to specific branches'

--- a/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.ServiceConnection.Rule.ps1
+++ b/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.ServiceConnection.Rule.ps1
@@ -4,7 +4,6 @@
 Rule 'Azure.DevOps.ServiceConnections.ProductionCheckProtection' `
     -Ref 'ADO-SC-001' `
     -Type 'Azure.DevOps.ServiceConnection' `
-    -With 'IsProduction' `
     -Tag @{ release = 'GA'} `
     -Level Warning {
         # Description 'Production service connection should be protected by one or more checks.'
@@ -18,7 +17,6 @@ Rule 'Azure.DevOps.ServiceConnections.ProductionCheckProtection' `
 Rule 'Azure.DevOps.ServiceConnections.ProductionHumanApproval' `
     -Ref 'ADO-SC-002' `
     -Type 'Azure.DevOps.ServiceConnection' `
-    -With 'IsProduction' `
     -Tag @{ release = 'GA'} `
     -Level Warning {
         # Description 'Production service connection should be protected by a human approval.'
@@ -80,7 +78,6 @@ Rule 'Azure.DevOps.ServiceConnections.WorkloadIdentityFederation' `
 Rule 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' `
     -Ref 'ADO-SC-006' `
     -Type 'Azure.DevOps.ServiceConnection' `
-    -With 'IsProduction' `
     -Tag @{ release = 'GA'} `
     -Level Warning {
         # Description 'Production service connection should be limited to specific branches.'

--- a/tests/Rules.Tests.ps1
+++ b/tests/Rules.Tests.ps1
@@ -1571,11 +1571,6 @@ Describe 'AzureDevOps ' {
     }
 
     Context 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' {
-        It 'Should not touch non-production service connections' {
-            $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -match 'fail$' })
-            $ruleHits.Count | Should -Be 0;
-        }
-
         It 'Should pass for production targets named success' {
             $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -like '*success*' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
@@ -1584,7 +1579,7 @@ Describe 'AzureDevOps ' {
 
         It 'Should be the same with a ReadOnly TokenType' {
             $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -match 'fail$' })
-            $ruleHits.Count | Should -Be 0;
+            $ruleHits.Count | Should -Be 3;
 
             $ruleHits = @($ruleResultReadOnly | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -like '*success*' })
             $ruleHits[0].Outcome | Should -Be 'Pass';
@@ -1593,7 +1588,7 @@ Describe 'AzureDevOps ' {
 
         It 'Should be the same with a FineGrained TokenType' {
             $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -match 'fail$' })
-            $ruleHits.Count | Should -Be 0;
+            $ruleHits.Count | Should -Be 3;
 
             $ruleHits = @($ruleResultFineGrained | Where-Object { $_.RuleName -eq 'Azure.DevOps.ServiceConnections.ProductionBranchLimit' -and $_.TargetName -like '*success*' })
             $ruleHits[0].Outcome | Should -Be 'Pass';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change removes the old PSRule selectors based system for focusing only on production resources. This means the module now looks at all exported resources regardsless of name. Of course it is not desirable to look at every branch in a repo. Therefore an example has been added on how to use PSRule _Suppression Groups_ for only targeting production bound Azure DevOps resources.

Although this change is not breaking in the sense of how to execute the tool and parameters accepted. The change does broaden the scope of inspection by PSRule and therefore may require action of the end-user in reporting.

## Related Issue

This fixes: #83 

## Motivation and Context

Better transperancy over which resources are audited + enhanced scope of audit.

## How Has This Been Tested?

Pester unit tests as in CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
