### PR TITLE
Fix Add -PassThru Parameter to Export Cmdlets #79

### DIFF
--- a/src/PSRule.Rules.AzureDevOps/Functions/Common.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/Common.ps1
@@ -157,6 +157,15 @@ function Get-AzDevOpsProject {
     .DESCRIPTION
     Export the Azure DevOps Project using Azure DevOps Rest API to a JSON file
 
+    .PARAMETER Project
+    Project name for Azure DevOps
+
+    .PARAMETER OutputPath
+    Output path for JSON files
+
+    .PARAMETER PassThru
+    Return the exported project as objects to the pipeline instead of writing to a file
+
     .EXAMPLE
     Export-AzDevOpsProject -Project $Project -OutputPath $OutputPath
 
@@ -170,9 +179,12 @@ function Export-AzDevOpsProject {
         [Parameter(Mandatory=$true)]
         [string]
         $Project,
-        [Parameter(Mandatory=$true)]
+        [Parameter(ParameterSetName = 'JsonFile')]
         [string]
-        $OutputPath
+        $OutputPath,
+        [Parameter(ParameterSetName = 'PassThru')]
+        [switch]
+        $PassThru
     )
     if ($null -eq $script:connection) {
         throw "Not connected to Azure DevOps. Run Connect-AzDevOps first"
@@ -188,6 +200,11 @@ function Export-AzDevOpsProject {
     catch {
         throw "Failed to get project $Project from Azure DevOps"
     }
-    $response | ConvertTo-Json | Out-File -FilePath "$OutputPath/$Project.prj.ado.json"
+    if($PassThru) {
+        Write-Output $response
+    } else {
+        Write-Verbose "Exporting project $Project as file $Project.prj.ado.json"
+        $response | ConvertTo-Json | Out-File -FilePath "$OutputPath/$Project.prj.ado.json"
+    }
 }
 # End of Function Export-AzDevOpsProject

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Groups.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Groups.ps1
@@ -122,6 +122,9 @@ Export-ModuleMember -Function Get-AzDevOpsGroupDetails
     .PARAMETER OutputPath
     The folder path to the JSON file to export to
 
+    .PARAMETER PassThru
+    Return the group details as an object instead of exporting to a file
+
     .EXAMPLE
     Export-AzDevOpsGroups -Project 'MyProject' -OutputPath 'C:\Temp\'
 
@@ -134,9 +137,12 @@ Function Export-AzDevOpsGroups {
         [Parameter(Mandatory=$true)]
         [string]
         $Project,
-        [Parameter(Mandatory=$true)]
+        [Parameter(ParameterSetName='JsonFile')]
         [string]
-        $OutputPath
+        $OutputPath,
+        [Parameter(ParameterSetName='PassThru')]
+        [switch]
+        $PassThru
     )
     if($null -eq $script:connection) {
         throw 'Not connected to Azure DevOps. Run Connect-AzDevOps first.'
@@ -157,7 +163,11 @@ Function Export-AzDevOpsGroups {
 
         $groupDetails += $thisGroup
     }
-    $groupDetails | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\groups.ado.json"
+    if($PassThru) {
+        Write-Output $groupDetails
+    } else {
+        $groupDetails | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\groups.ado.json"
+    }
 }
 Export-ModuleMember -Function Export-AzDevOpsGroups
 # End of Function Export-AzDevOpsGroups

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Environments.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Environments.ps1
@@ -126,6 +126,12 @@ Export-ModuleMember -Function Get-AzDevOpsEnvironmentChecks
     .PARAMETER Project
     Project name for Azure DevOps
 
+    .PARAMETER OutputPath
+    Path to output JSON files
+
+    .PARAMETER PassThru
+    Return the exported environments as objects to the pipeline instead of writing to a file
+
     .EXAMPLE
     Export-AzDevOpsEnvironmentChecks -Project $Project
 #>
@@ -136,9 +142,12 @@ function Export-AzDevOpsEnvironmentChecks {
         [Parameter(Mandatory)]
         [string]
         $Project,
-        [Parameter(Mandatory)]
+        [Parameter(ParameterSetName = 'JsonFile')]
         [string]
-        $OutputPath
+        $OutputPath,
+        [Parameter(ParameterSetName = 'PassThru')]
+        [switch]
+        $PassThru
 
     )
     if ($null -eq $script:connection) {
@@ -159,9 +168,13 @@ function Export-AzDevOpsEnvironmentChecks {
                 $environment | Add-Member -MemberType NoteProperty -Name ObjectName -Value ("{0}.{1}.{2}" -f $script:connection.Organization,$Project,$environment.name)
                 $checks = @(Get-AzDevOpsEnvironmentChecks -Project $Project -Environment $environment.id)
                 $environment | Add-Member -MemberType NoteProperty -Name checks -Value $checks
-                Write-Verbose "Exporting environment $($environment.name) to JSON"
-                Write-Verbose "Output file: $OutputPath\$($environment.name).ado.env.json"
-                $environment | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\$($environment.name).ado.env.json"
+                if($PassThru) {
+                    Write-Output $environment
+                } else {
+                    Write-Verbose "Exporting environment $($environment.name) to JSON"
+                    Write-Verbose "Output file: $OutputPath\$($environment.name).ado.env.json"
+                    $environment | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\$($environment.name).ado.env.json"
+                }
             }
         }
     }

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Settings.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Settings.ps1
@@ -53,6 +53,9 @@ Export-ModuleMember -Function Get-AzDevOpsPipelinesSettings
     .PARAMETER OutputPath
     Output path for JSON files
 
+    .PARAMETER PassThru
+    Return the exported pipelines settings as objects to the pipeline instead of writing to a file
+
     .EXAMPLE
     Export-AzDevOpsPipelinesSettings -Project $Project -OutputPath $OutputPath
 #>
@@ -62,9 +65,12 @@ function Export-AzDevOpsPipelinesSettings {
         [Parameter(Mandatory)]
         [string]
         $Project,
-        [Parameter(Mandatory)]
+        [Parameter(ParameterSetName = 'JsonFile')]
         [string]
-        $OutputPath
+        $OutputPath,
+        [Parameter(ParameterSetName = 'PassThru')]
+        [switch]
+        $PassThru
     )
     if ($null -eq $script:connection) {
         throw "Not connected to Azure DevOps. Run Connect-AzDevOps first"
@@ -74,7 +80,11 @@ function Export-AzDevOpsPipelinesSettings {
     $pipelinesSettings | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.Pipelines.Settings'
     $pipelinesSettings | Add-Member -MemberType NoteProperty -Name ObjectName -Value ("{0}.{1}.PipelineSettings" -f $script:connection.Organization,$Project)
     $pipelinesSettings | Add-Member -MemberType NoteProperty -Name Name -Value $Project
-    $pipelinesSettings | ConvertTo-Json -Depth 10 | Out-File (Join-Path -Path $OutputPath -ChildPath "$Project.ado.pls.json")
+    if ($PassThru) {
+        Write-Output $pipelinesSettings
+    } else {
+        $pipelinesSettings | ConvertTo-Json -Depth 10 | Out-File (Join-Path -Path $OutputPath -ChildPath "$Project.ado.pls.json")
+    }
 }
 Export-ModuleMember -Function Export-AzDevOpsPipelinesSettings
 # End of Function Export-AzDevOpsPipelinesSettings

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.RetentionSettings.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.RetentionSettings.ps1
@@ -62,6 +62,9 @@ Export-ModuleMember -Function Get-AzDevOpsRetentionSettings
     .PARAMETER OutputPath
     The path to export the retention settings to.
 
+    .PARAMETER PassThru
+    If set, the function will return the retention settings as objects instead of writing them to a file.
+
     .EXAMPLE
     Get-AzDevOpsRetentionSettings -Project 'MyProject' -OutputPath 'C:\Temp\'
 
@@ -75,11 +78,19 @@ Function Export-AzDevOpsRetentionSettings {
         [string]
         $Project,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(ParameterSetName = 'JsonFile')]
         [string]
-        $OutputPath
+        $OutputPath,
+
+        [Parameter(ParameterSetName = 'PassThru')]
+        [switch]
+        $PassThru
     )
     $settings = Get-AzDevOpsRetentionSettings -Project $Project
-    $settings | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\$($Project).ret.ado.json"
+    if($PassThru) {
+        Write-Output $settings
+    } else {
+        $settings | ConvertTo-Json -Depth 100 | Out-File -FilePath "$OutputPath\$($Project).ret.ado.json"
+    }
 }
 Export-ModuleMember -Function Export-AzDevOpsRetentionSettings

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
@@ -104,6 +104,9 @@ Export-ModuleMember -Function Get-AzDevOpsServiceConnectionChecks
     .PARAMETER OutputPath
     Output path for JSON files
 
+    .PARAMETER PassThru
+    Return the exported service connections as objects to the pipeline instead of writing to a file
+
     .EXAMPLE
     Export-AzDevOpsServiceConnections -Project $Project -OutputPath $OutputPath
 
@@ -116,9 +119,12 @@ function Export-AzDevOpsServiceConnections {
         [Parameter(Mandatory)]
         [string]
         $Project,
-        [Parameter(Mandatory)]
+        [Parameter(ParameterSetName = 'JsonFile')]
         [string]
-        $OutputPath
+        $OutputPath,
+        [Parameter(ParameterSetName = 'PassThru')]
+        [switch]
+        $PassThru
     )
     if ($null -eq $script:connection) {
         throw "Not connected to Azure DevOps. Run Connect-AzDevOps first"
@@ -135,8 +141,12 @@ function Export-AzDevOpsServiceConnections {
         # Get checks for service connection
         $serviceConnectionChecks = @(Get-AzDevOpsServiceConnectionChecks -Project $Project -ServiceConnectionId $serviceConnection.id)
         $serviceConnection | Add-Member -MemberType NoteProperty -Name Checks -Value $serviceConnectionChecks
-        Write-Verbose "Exporting service connection $($serviceConnection.name) as file $($serviceConnection.name).ado.sc.json"
-        $serviceConnection | ConvertTo-Json -Depth 100 | Out-File "$OutputPath/$($serviceConnection.name).ado.sc.json"
+        if ($PassThru) {
+            Write-Output $serviceConnection
+        } else {
+            Write-Verbose "Exporting service connection $($serviceConnection.name) as file $($serviceConnection.name).ado.sc.json"
+            $serviceConnection | ConvertTo-Json -Depth 100 | Out-File "$OutputPath/$($serviceConnection.name).ado.sc.json"
+        }
     }
 }
 Export-ModuleMember -Function Export-AzDevOpsServiceConnections

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Tasks.VariableGroups.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Tasks.VariableGroups.ps1
@@ -54,6 +54,9 @@ Export-ModuleMember -Function Get-AzDevOpsVariableGroups
     .PARAMETER OutputPath
     The path to export variable groups to.
 
+    .PARAMETER PassThru
+    Return the exported variable groups as objects to the pipeline instead of writing to a file.
+
     .EXAMPLE
     Export-AzDevOpsVariableGroups -Project 'myproject' -OutputPath 'C:\temp'
 
@@ -69,9 +72,13 @@ Function Export-AzDevOpsVariableGroups {
         [string]
         $Project,
 
-        [Parameter(Mandatory)]
+        [Parameter(ParameterSetName = 'JsonFile')]
         [string]
-        $OutputPath
+        $OutputPath,
+
+        [Parameter(ParameterSetName = 'PassThru')]
+        [switch]
+        $PassThru
     )
     if ($null -eq $script:connection) {
         throw "Not connected to Azure DevOps. Run Connect-AzDevOps first"
@@ -83,9 +90,13 @@ Function Export-AzDevOpsVariableGroups {
         $variableGroup | Add-Member -MemberType NoteProperty -Name 'ObjectType' -Value 'Azure.DevOps.Tasks.VariableGroup'
         $variableGroup | Add-Member -MemberType NoteProperty -Name 'ObjectName' -Value "$Organization.$Project.$($variableGroup.name)"
         $variableGroupName = $variableGroup.name
-        $variableGroupPath = Join-Path -Path $OutputPath -ChildPath "$variableGroupName.ado.vg.json"
-        Write-Verbose "Exporting variable group $variableGroupName as file $variableGroupName.ado.vg.json"
-        $variableGroup | ConvertTo-Json -Depth 100 | Out-File -FilePath $variableGroupPath -Encoding UTF8
+        if ($PassThru) {
+            Write-Output $variableGroup
+        } else {
+            $variableGroupPath = Join-Path -Path $OutputPath -ChildPath "$variableGroupName.ado.vg.json"
+            Write-Verbose "Exporting variable group $variableGroupName as file $variableGroupName.ado.vg.json"
+            $variableGroup | ConvertTo-Json -Depth 100 | Out-File -FilePath $variableGroupPath -Encoding UTF8
+        }
     }
 }
 Export-ModuleMember -Function Export-AzDevOpsVariableGroups

--- a/src/PSRule.Rules.AzureDevOps/PSRule.Rules.AzureDevOps.psm1
+++ b/src/PSRule.Rules.AzureDevOps/PSRule.Rules.AzureDevOps.psm1
@@ -27,6 +27,9 @@ Get-ChildItem -Path "$PSScriptRoot/Functions/*.ps1" | ForEach-Object {
     .PARAMETER OutputPath
     Output path for JSON files
 
+    .PARAMETER PassThru
+    Return the exported project as objects to the pipeline instead of writing to a file
+
     .EXAMPLE
     Export-AzDevOpsRuleData -Project $Project -OutputPath $OutputPath
 #>
@@ -36,31 +39,61 @@ Function Export-AzDevOpsRuleData {
         [Parameter(Mandatory)]
         [string]
         $Project,
-        [Parameter(Mandatory)]
+        [Parameter(ParameterSetName = 'JsonFile')]
         [string]
-        $OutputPath
+        $OutputPath,
+        [Parameter(ParameterSetName = 'PassThru')]
+        [switch]
+        $PassThru
     )
-    Write-Verbose "Exporting rule data for project $Project to $OutputPath"
-    Write-Verbose "Exporting project"
-    Export-AzDevOpsProject -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting repos and branch policies"
-    Export-AzDevOpsReposAndBranchPolicies -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting environment checks"
-    Export-AzDevOpsEnvironmentChecks -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting service connections"
-    Export-AzDevOpsServiceConnections -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting pipelines"
-    Export-AzDevOpsPipelines -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting pipelines settings"
-    Export-AzDevOpsPipelinesSettings -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting variable groups"
-    Export-AzDevOpsVariableGroups -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting release definitions"
-    Export-AzDevOpsReleaseDefinitions -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting groups"
-    Export-AzDevOpsGroups -Project $Project -OutputPath $OutputPath
-    Write-Verbose "Exporting retention settings"
-    Export-AzDevOpsRetentionSettings -Project $Project -OutputPath $OutputPath
+    if ($null -eq $script:connection) {
+        throw "Not connected to Azure DevOps. Run Connect-AzDevOps first"
+    }
+    if($PassThru) {
+        Write-Verbose "Exporting rule data for project $Project to $OutputPath"
+        Write-Verbose "Exporting project"
+        Export-AzDevOpsProject -Project $Project -PassThru
+        Write-Verbose "Exporting repos and branch policies"
+        Export-AzDevOpsReposAndBranchPolicies -Project $Project -PassThru
+        Write-Verbose "Exporting environment checks"
+        Export-AzDevOpsEnvironmentChecks -Project $Project -PassThru
+        Write-Verbose "Exporting service connections"
+        Export-AzDevOpsServiceConnections -Project $Project -PassThru
+        Write-Verbose "Exporting pipelines"
+        Export-AzDevOpsPipelines -Project $Project -PassThru
+        Write-Verbose "Exporting pipelines settings"
+        Export-AzDevOpsPipelinesSettings -Project $Project -PassThru
+        Write-Verbose "Exporting variable groups"
+        Export-AzDevOpsVariableGroups -Project $Project -PassThru
+        Write-Verbose "Exporting release definitions"
+        Export-AzDevOpsReleaseDefinitions -Project $Project -PassThru
+        Write-Verbose "Exporting groups"
+        Export-AzDevOpsGroups -Project $Project -PassThru
+        Write-Verbose "Exporting retention settings"
+        Export-AzDevOpsRetentionSettings -Project $Project -PassThru
+    } else {
+        Write-Verbose "Exporting rule data for project $Project to $OutputPath"
+        Write-Verbose "Exporting project"
+        Export-AzDevOpsProject -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting repos and branch policies"
+        Export-AzDevOpsReposAndBranchPolicies -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting environment checks"
+        Export-AzDevOpsEnvironmentChecks -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting service connections"
+        Export-AzDevOpsServiceConnections -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting pipelines"
+        Export-AzDevOpsPipelines -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting pipelines settings"
+        Export-AzDevOpsPipelinesSettings -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting variable groups"
+        Export-AzDevOpsVariableGroups -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting release definitions"
+        Export-AzDevOpsReleaseDefinitions -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting groups"
+        Export-AzDevOpsGroups -Project $Project -OutputPath $OutputPath
+        Write-Verbose "Exporting retention settings"
+        Export-AzDevOpsRetentionSettings -Project $Project -OutputPath $OutputPath
+    }
 }
 Export-ModuleMember -Function Export-AzDevOpsRuleData -Alias Export-AzDevOpsProjectRuleData
 # End of Function Export-AzDevOpsRuleData

--- a/tests/Common.Tests.ps1
+++ b/tests/Common.Tests.ps1
@@ -284,6 +284,39 @@ Describe "Functions: Common.Tests" {
             } | Should -Throw 
         }
     }
+
+    Context " Export-AzDevOpsProject -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $project = Get-AzDevOpsProject -Project $env:ADO_PROJECT
+            $projectDetails = Export-AzDevOpsProject -Project $project.name -PassThru
+            $ruleResult = $projectDetails | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It " The output should be of type [PSCustomObject]" {
+            $projectDetails | Should -BeOfType [PSCustomObject]
+        }
+
+        It " The output should have a ObjectType property" {
+            $projectDetails | Select -ExpandProperty ObjectType | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have a ObjectName property" {
+            $projectDetails | Select -ExpandProperty ObjectName | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+
+        AfterAll {
+            Disconnect-AzDevOps
+        }
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.Groups.Tests.ps1
+++ b/tests/DevOps.Groups.Tests.ps1
@@ -296,6 +296,38 @@ Describe "Azure.DevOps.Group" {
             } | Should -Throw
         }
     }
+
+    Context " Export-AzDevOpsGroups -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $groups = Export-AzDevOpsGroups -Project $env:ADO_PROJECT -PassThru
+            $ruleResult = $groups | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It " Should return a list of groups" {
+            $groups | Should -Not -BeNullOrEmpty
+        }
+
+        It " Should return a list of groups with an ObjectType property" {
+            $groups[0].ObjectType | Should -Not -BeNullOrEmpty
+        }
+
+        It " Should return a list of groups with an ObjectName property" {
+            $groups[0].ObjectName | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+
+        AfterAll {
+            Disconnect-AzDevOps
+        }
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.Pipelines.Core.Tests.ps1
+++ b/tests/DevOps.Pipelines.Core.Tests.ps1
@@ -268,6 +268,43 @@ Describe "Functions: DevOps.Pipelines.Core.Tests" {
             Disconnect-AzDevOps
         }
     }
+
+    Context " Export-AzDevOpsPipelines -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $pipelines = Export-AzDevOpsPipelines -Project $env:ADO_PROJECT -PassThru
+            $ruleResult = $pipelines | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It " should return a list of pipelines" {
+            $pipelines | Should -Not -BeNullOrEmpty
+        }
+
+        It " should return a list of pipelines that are of type PSObject" {
+            $pipelines[1] | Should -BeOfType [PSCustomObject]
+        }
+
+        It " should return a list of pipelines that have an ObjectType field with a value of Azure.DevOps.Pipeline" {
+            $pipelines[1].ObjectType | Should -Be "Azure.DevOps.Pipeline"
+        }
+
+        It " should return a list of pipelines that have an ObjectName field" {
+            $pipelines[1].ObjectName | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+
+        AfterAll {
+            Disconnect-AzDevOps
+        }
+    
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.Pipelines.Core.Tests.ps1
+++ b/tests/DevOps.Pipelines.Core.Tests.ps1
@@ -273,7 +273,7 @@ Describe "Functions: DevOps.Pipelines.Core.Tests" {
         BeforeAll {
             Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
             $pipelines = Export-AzDevOpsPipelines -Project $env:ADO_PROJECT -PassThru
-            $ruleResult = $pipelines | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+            $ruleResult = $pipelines | Where-Object { $null -ne $_ } | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
         }
 
         It " should return a list of pipelines" {

--- a/tests/DevOps.Pipelines.Environments.Tests.ps1
+++ b/tests/DevOps.Pipelines.Environments.Tests.ps1
@@ -210,6 +210,43 @@ Describe "Functions: Azure.DevOps.Pipelines.Environments.Tests" {
             Disconnect-AzDevOps
         }
     }
+
+    Context " Export-AzDevOpsEnvironmentChecks -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $environmentChecks = Export-AzDevOpsEnvironmentChecks -Project $env:ADO_PROJECT -PassThru
+            $ruleResult = $environmentChecks | Invoke-PSRule -Module PSRule.Rules.AzureDevOps -Culture en
+        }
+
+        It " should return a list of environment checks" {
+            $environmentChecks | Should -Not -BeNullOrEmpty
+        }
+
+        It " should return a list of environment checks that are of type PSObject" {
+            $environmentChecks[0] | Should -BeOfType [PSCustomObject]
+        }
+
+        It " should return a list of object with an ObjectType property" {
+            $environmentChecks[0].ObjectType | Should -Not -BeNullOrEmpty
+        }
+
+        It " should return a list of object with an ObjectName property" {
+            $environmentChecks[0].ObjectName | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+
+        AfterAll {
+            Disconnect-AzDevOps
+        }
+    
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.Pipelines.Releases.Tests.ps1
+++ b/tests/DevOps.Pipelines.Releases.Tests.ps1
@@ -176,6 +176,45 @@ Describe "Functions: DevOps.Pipelines.Releases.Tests" {
             Disconnect-AzDevOps
         }
     }
+
+    Context " Export-AzDevOpsReleaseDefinitions -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $Project = $env:ADO_PROJECT
+            $releaseDefinitions = Export-AzDevOpsReleaseDefinitions -Project $Project -PassThru
+            $ruleResult = $releaseDefinitions | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It " should return a list of release definitions" {
+            $releaseDefinitions | Should -Not -BeNullOrEmpty
+        }
+
+        It " should return a list of release definitions that are of type PSObject" {
+            $releaseDefinitions[0] | Should -BeOfType [PSCustomObject]
+        }
+
+        It " should return a list of release definitions that have an ObjectType" {
+            $releaseDefinitions[0].ObjectType | Should -Not -BeNullOrEmpty
+            $releaseDefinitions[0].ObjectType | Should -BeOfType [string]
+        }
+
+        It " should return a list of release definitions that have an ObjectName" {
+            $releaseDefinitions[0].ObjectName | Should -Not -BeNullOrEmpty
+            $releaseDefinitions[0].ObjectName | Should -BeOfType [string]
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+
+        AfterAll {
+            Disconnect-AzDevOps
+        }
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.Pipelines.Settings.Tests.ps1
+++ b/tests/DevOps.Pipelines.Settings.Tests.ps1
@@ -71,6 +71,38 @@ Describe "Functions: DevOps.Pipelines.Settings.Tests" {
             $json.ObjectType | Should -Be "Azure.DevOps.Pipelines.Settings"
         }
     }
+
+    Context " Export-AzDevOpsPipelinesSettings -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $settings = Export-AzDevOpsPipelinesSettings -Project $env:ADO_PROJECT -PassThru
+            $ruleResult = $settings | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It " should return project pipeline settings" {
+            $settings | Should -Not -BeNullOrEmpty
+        }
+
+        It " should return project pipeline settings that are of type PSObject" {
+            $settings | Should -BeOfType [PSCustomObject]
+        }
+
+        It " should return project pipeline settings with an ObjectType of Azure.DevOps.Pipelines.Settings" {
+            $settings.ObjectType | Should -Be "Azure.DevOps.Pipelines.Settings"
+        }
+
+        It " should return project pipeline settings with an ObjectName of {Organization}.{Project}.PipelineSettings" {
+            $settings.ObjectName | Should -Be ("{0}.{1}.PipelineSettings" -f $env:ADO_ORGANIZATION,$env:ADO_PROJECT)
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.Repos.Tests.ps1
+++ b/tests/DevOps.Repos.Tests.ps1
@@ -388,6 +388,39 @@ Describe "Functions: DevOps.Repos.Tests" {
             }
         }
     }
+
+    Context " Export-AzDevOpsReposAndBranchPolicies -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $Project = $env:ADO_PROJECT
+            $repos = Export-AzDevOpsReposAndBranchPolicies -Project $Project -PassThru
+            $ruleResult = $repos | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It " should return project repos" {
+            $repos | Should -Not -BeNullOrEmpty
+        }
+
+        It " should return project repos that are of type PSObject" {
+            $repos[0] | Should -BeOfType [PSCustomObject]
+        }
+
+        It " should return project repos with an ObjectType" {
+            $repos[0].ObjectType | Should -Not -BeNullOrEmpty
+        }
+
+        It " should return project repos with an ObjectName" {
+            $repos[0].ObjectName | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.RetentionSettings.Tests.ps1
+++ b/tests/DevOps.RetentionSettings.Tests.ps1
@@ -134,6 +134,46 @@ Describe 'Azure.DevOps.RetentionSettings' {
             } | Should -Throw "Failed to get retention settings for project 'wrongProject' from Azure DevOps"
         }
     }
+
+    Context ' Export-AzDevOpsRetentionSettings -PassThru' {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $settings = Export-AzDevOpsRetentionSettings -Project $env:ADO_PROJECT -PassThru
+            $ruleResult = $settings | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It 'should return a hashtable' {
+            $settings | Should -BeOfType [hashtable]
+        }
+
+        It 'should return a hashtable with RetentionSettings property' {
+            $settings.RetentionSettings | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should return a hashtable with RetentionPolicy property' {
+            $settings.RetentionPolicy | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should return a hashtable with ObjectType property' {
+            $settings.ObjectType | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should return a hashtable with ObjectName property' {
+            $settings.ObjectName | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+
+        AfterAll {
+            Disconnect-AzDevOps
+        }
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.ServiceConnections.Tests.ps1
+++ b/tests/DevOps.ServiceConnections.Tests.ps1
@@ -136,6 +136,41 @@ Describe "Functions: DevOps.ServiceConnections.Tests" {
             }
         }
     }
+
+    Context " Export-AzDevOpsServiceConnections -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $Project = $env:ADO_PROJECT
+            $serviceConnections = Export-AzDevOpsServiceConnections -Project $Project -PassThru
+            $ruleResult = $serviceConnections | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It " should return a list of service connections" {
+            $serviceConnections | Should -Not -BeNullOrEmpty
+        }
+
+        It " should return a list of service connections that are of type PSObject" {
+            $serviceConnections[0] | Should -BeOfType [PSCustomObject]
+        }
+
+        It " should return a list of service connections that have an ObjectName" {
+            $serviceConnections[0].ObjectName | Should -Not -BeNullOrEmpty
+            $serviceConnections[0].ObjectName | Should -BeOfType [string]
+        }
+
+        It " should return a list of service connections that have an ObjectType" {
+            $serviceConnections[0].ObjectType | Should -Not -BeNullOrEmpty
+            $serviceConnections[0].ObjectType | Should -BeOfType [string]
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+    }
 }
 
 AfterAll {

--- a/tests/DevOps.Tasks.VariableGroups.Tests.ps1
+++ b/tests/DevOps.Tasks.VariableGroups.Tests.ps1
@@ -91,6 +91,41 @@ Describe "Functions: DevOps.Tasks.VariableGroups.Tests" {
             $json.ObjectType | Should -Be "Azure.DevOps.Tasks.VariableGroup"
         }
     }
+
+    Context " Export-AzDevOpsVariableGroups -PassThru" {
+        BeforeAll {
+            Connect-AzDevOps -Organization $env:ADO_ORGANIZATION -PAT $env:ADO_PAT
+            $Project = $env:ADO_PROJECT
+            $variableGroups = Export-AzDevOpsVariableGroups -Project $Project -PassThru
+            $ruleResult = $variableGroups | Invoke-PSRule -Module @('PSRule.Rules.AzureDevOps') -Culture en
+        }
+
+        It ' should return a list of variable groups' {
+            $variableGroups | Should -Not -BeNullOrEmpty
+        }
+
+        It ' should return a list of variable groups that are of type PSObject' {
+            $variableGroups[0] | Should -BeOfType [PSCustomObject]
+        }
+
+        It ' should return a list of variable groups with an ObjectName' {
+            $variableGroups[0].ObjectName | Should -Not -BeNullOrEmpty
+            $variableGroups[0].ObjectName | Should -BeOfType [System.String]
+        }
+
+        It ' should return a list of variable groups with an ObjectType' {
+            $variableGroups[0].ObjectType | Should -Not -BeNullOrEmpty
+            $variableGroups[0].ObjectType | Should -BeOfType [System.String]
+        }
+
+        It " The output should have results with Invoke-PSRule" {
+            $ruleResult | Should -Not -BeNullOrEmpty
+        }
+
+        It " The output should have results with Invoke-PSRule that are of type [PSRule.Rules.RuleRecord]" {
+            $ruleResult[0] | Should -BeOfType [PSRule.Rules.RuleRecord]
+        }
+    }
 }
 
 AfterAll {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add `-PassThru` parameter to output object to pipeline instead of saving JSON to filesystem

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fix #79 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Azure DevOps project configuration contains sensitive information and end-users should be able to process it in memory and not save it to filesystem

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Pester tests have been implemented and tested on developer workstation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
