### PR TITLE
Experiment/id as object

### DIFF
--- a/src/PSRule.Rules.AzureDevOps/Functions/Common.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/Common.ps1
@@ -196,6 +196,11 @@ function Export-AzDevOpsProject {
         $response = Get-AzDevOpsProject -Project $Project
         $response | Add-Member -MemberType NoteProperty -Name ObjectType -Value "Azure.DevOps.Project"
         $response | Add-Member -MemberType NoteProperty -Name ObjectName -Value "$Organization.$Project"
+        $response.id = @{ 
+            originalId      = $response.id;
+            project         = $Project;
+            organization    = $Organization
+        } | ConvertTo-Json -Depth 100
     }
     catch {
         throw "Failed to get project $Project from Azure DevOps"

--- a/src/PSRule.Rules.AzureDevOps/Functions/Common.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/Common.ps1
@@ -198,6 +198,7 @@ function Export-AzDevOpsProject {
         $response | Add-Member -MemberType NoteProperty -Name ObjectName -Value "$Organization.$Project"
         $response.id = @{ 
             originalId      = $response.id;
+            resourceName    = $response.name;
             project         = $Project;
             organization    = $Organization
         } | ConvertTo-Json -Depth 100

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Groups.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Groups.ps1
@@ -160,8 +160,12 @@ Function Export-AzDevOpsGroups {
         $thisGroup | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.Group' -Force
         # Add the group name to the group object as an ObjectName property with a convention of Organization.Project.GroupName
         $thisGroup | Add-Member -MemberType NoteProperty -Name ObjectName -Value "$($script:connection.Organization).$($Project).$($group.displayName)" -Force
+        # set the name to the displayName
+        $thisGroup | Add-Member -MemberType NoteProperty -Name name -Value $group.displayName -Force
+        # Set the id to a JSON object with the originalId, project and organization
         $id = @{
             originalId = $null
+            resourceName = $group.displayName
             project = $Project
             organization = $script:connection.Organization
         } | ConvertTo-Json -Depth 100

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Groups.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Groups.ps1
@@ -160,7 +160,12 @@ Function Export-AzDevOpsGroups {
         $thisGroup | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.Group' -Force
         # Add the group name to the group object as an ObjectName property with a convention of Organization.Project.GroupName
         $thisGroup | Add-Member -MemberType NoteProperty -Name ObjectName -Value "$($script:connection.Organization).$($Project).$($group.displayName)" -Force
-
+        $id = @{
+            originalId = $null
+            project = $Project
+            organization = $script:connection.Organization
+        } | ConvertTo-Json -Depth 100
+        $thisGroup | Add-Member -MemberType NoteProperty -Name id -Value $id -Force
         $groupDetails += $thisGroup
     }
     if($PassThru) {

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Environments.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Environments.ps1
@@ -172,6 +172,7 @@ function Export-AzDevOpsEnvironmentChecks {
                 # Set the id property to a hash table with the original id, organization and project name
                 $environment.id = @{
                     originalId = $environment.id
+                    resourceName = $environment.name
                     project = $Project
                     organization = $script:connection.Organization
                 } | ConvertTo-Json -Depth 100

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Environments.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Environments.ps1
@@ -166,8 +166,15 @@ function Export-AzDevOpsEnvironmentChecks {
                 # Add a ObjectType indicator for Azure.DevOps.Pipelines.Environment
                 $environment | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.Pipelines.Environment'
                 $environment | Add-Member -MemberType NoteProperty -Name ObjectName -Value ("{0}.{1}.{2}" -f $script:connection.Organization,$Project,$environment.name)
+
                 $checks = @(Get-AzDevOpsEnvironmentChecks -Project $Project -Environment $environment.id)
                 $environment | Add-Member -MemberType NoteProperty -Name checks -Value $checks
+                # Set the id property to a hash table with the original id, organization and project name
+                $environment.id = @{
+                    originalId = $environment.id
+                    project = $Project
+                    organization = $script:connection.Organization
+                } | ConvertTo-Json -Depth 100
                 if($PassThru) {
                     Write-Output $environment
                 } else {

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Releases.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Releases.ps1
@@ -164,6 +164,15 @@ Function Export-AzDevOpsReleaseDefinitions {
             # Add an ObjectType of Azure.DevOps.Pipelines.Releases.Definition to the response
             $response | Add-Member -MemberType NoteProperty -Name 'ObjectType' -Value 'Azure.DevOps.Pipelines.Releases.Definition'
             $response | Add-Member -MemberType NoteProperty -Name 'ObjectName' -Value ("{0}.{1}.{2}" -f $script:connection.Organization,$Project,$definitionName)
+
+            # Set the id to the to a hashtable of the organization, project and original id
+            $id = @{
+                originalId = $null
+                project = $Project
+                organization = $Organization
+            } | ConvertTo-Json -Depth 100
+            $response.id = $id
+
             # Get the project ID from the url in the response
             $projectId = $response.url.Split('/')[4]
             # Get the folder from the path in the response

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Releases.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Releases.ps1
@@ -168,6 +168,7 @@ Function Export-AzDevOpsReleaseDefinitions {
             # Set the id to the to a hashtable of the organization, project and original id
             $id = @{
                 originalId = $null
+                resourceName = $definitionName
                 project = $Project
                 organization = $Organization
             } | ConvertTo-Json -Depth 100

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Settings.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Settings.ps1
@@ -79,9 +79,10 @@ function Export-AzDevOpsPipelinesSettings {
     $pipelinesSettings = Get-AzDevOpsPipelinesSettings -Project $Project
     $pipelinesSettings | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.Pipelines.Settings'
     $pipelinesSettings | Add-Member -MemberType NoteProperty -Name ObjectName -Value ("{0}.{1}.PipelineSettings" -f $script:connection.Organization,$Project)
-    $pipelinesSettings | Add-Member -MemberType NoteProperty -Name Name -Value $Project
+    $pipelinesSettings | Add-Member -MemberType NoteProperty -Name Name -Value "PipelineSettings"
     $id = @{
         originalId = $null
+        resourceName = 'PipelineSettings'
         project = $Project
         organization = $script:connection.Organization
     } | ConvertTo-Json -Depth 100

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Settings.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Pipelines.Settings.ps1
@@ -80,6 +80,12 @@ function Export-AzDevOpsPipelinesSettings {
     $pipelinesSettings | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.Pipelines.Settings'
     $pipelinesSettings | Add-Member -MemberType NoteProperty -Name ObjectName -Value ("{0}.{1}.PipelineSettings" -f $script:connection.Organization,$Project)
     $pipelinesSettings | Add-Member -MemberType NoteProperty -Name Name -Value $Project
+    $id = @{
+        originalId = $null
+        project = $Project
+        organization = $script:connection.Organization
+    } | ConvertTo-Json -Depth 100
+    $pipelinesSettings | Add-Member -MemberType NoteProperty -Name id -Value $id
     if ($PassThru) {
         Write-Output $pipelinesSettings
     } else {

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
@@ -454,6 +454,7 @@ function Export-AzDevOpsReposAndBranchPolicies {
                 $branch | Add-Member -MemberType NoteProperty -Name ObjectName -Value ("{0}.{1}.{2}.{3}" -f $Organization,$Project,$repo.name,$branch.name)
                 $id = @{ 
                     originalId      = $branch.objectId;
+                    resourceName    = "$($repo.name)/$($branch.name)"
                     project         = $Project;
                     organization    = $Organization
                 } | ConvertTo-Json -Depth 100
@@ -478,14 +479,17 @@ function Export-AzDevOpsReposAndBranchPolicies {
             # Add a property with pipeline permissions
             $pipelinePermissions = Get-AzDevOpsRepositoryPipelinePermissions -ProjectId $repo.project.id -RepositoryId $repo.id
             $repo | Add-Member -MemberType NoteProperty -Name PipelinePermissions -Value $pipelinePermissions
+            $repoId = $repo.id
+            # Set the id property to a hash table with the original id, organization and project name
             $repo.id = @{ 
                 originalId      = $repo.id;
+                resourceName    = $repo.name;
                 project         = $Project;
                 organization    = $Organization
             } | ConvertTo-Json -Depth 100
             # Add a property with repo ACLs if the token type is not ReadOnly
             if ($TokenType -ne "ReadOnly") {
-                $repoAcls = Get-AzDevOpsRepositoryAcls -ProjectId $repo.project.id -RepositoryId $repo.id
+                $repoAcls = Get-AzDevOpsRepositoryAcls -ProjectId $repo.project.id -RepositoryId $repoId
                 $repo | Add-Member -MemberType NoteProperty -Name Acls -Value $repoAcls
             }
             $branches += $repo

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
@@ -471,7 +471,11 @@ function Export-AzDevOpsReposAndBranchPolicies {
             # Add a property with pipeline permissions
             $pipelinePermissions = Get-AzDevOpsRepositoryPipelinePermissions -ProjectId $repo.project.id -RepositoryId $repo.id
             $repo | Add-Member -MemberType NoteProperty -Name PipelinePermissions -Value $pipelinePermissions
-
+            $repo.id = @{ 
+                originalId      = $repo.id;
+                project         = $Project;
+                organization    = $Organization
+            } | ConvertTo-Json -Depth 100
             # Add a property with repo ACLs if the token type is not ReadOnly
             if ($TokenType -ne "ReadOnly") {
                 $repoAcls = Get-AzDevOpsRepositoryAcls -ProjectId $repo.project.id -RepositoryId $repo.id

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
@@ -451,6 +451,12 @@ function Export-AzDevOpsReposAndBranchPolicies {
                 $branch | Add-Member -MemberType NoteProperty -Name ObjectType -Value "Azure.DevOps.Repo.Branch"
                 # Add ObjectName to branch object
                 $branch | Add-Member -MemberType NoteProperty -Name ObjectName -Value ("{0}.{1}.{2}.{3}" -f $Organization,$Project,$repo.name,$branch.name)
+                $id = @{ 
+                    originalId      = $branch.objectId;
+                    project         = $Project;
+                    organization    = $Organization
+                } | ConvertTo-Json -Depth 100
+                $branch | Add-Member -MemberType NoteProperty -Name id -Value $id
                 $branch
             }
 

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.RetentionSettings.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.RetentionSettings.ps1
@@ -87,6 +87,12 @@ Function Export-AzDevOpsRetentionSettings {
         $PassThru
     )
     $settings = Get-AzDevOpsRetentionSettings -Project $Project
+    $id = @{
+        originalId = $null
+        project = $Project
+        organization = $script:connection.Organization
+    } | ConvertTo-Json -Depth 100
+    $settings.Add('id',$id)
     if($PassThru) {
         Write-Output $settings
     } else {

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.RetentionSettings.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.RetentionSettings.ps1
@@ -89,10 +89,12 @@ Function Export-AzDevOpsRetentionSettings {
     $settings = Get-AzDevOpsRetentionSettings -Project $Project
     $id = @{
         originalId = $null
+        resourceName = 'RetentionSettings'
         project = $Project
         organization = $script:connection.Organization
     } | ConvertTo-Json -Depth 100
     $settings.Add('id',$id)
+    $settings.Add('name','RetentionSettings')
     if($PassThru) {
         Write-Output $settings
     } else {

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
@@ -145,6 +145,7 @@ function Export-AzDevOpsServiceConnections {
         # Set id field to a JSON object with originalId, project and organization
         $serviceConnection.id = @{
             originalId = $serviceConnection.id
+            resourceName = $serviceConnection.name
             project = $Project
             organization = $Organization
         } | ConvertTo-Json -Depth 100

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
@@ -138,9 +138,16 @@ function Export-AzDevOpsServiceConnections {
         $serviceConnection | Add-Member -MemberType NoteProperty -Name ObjectType -Value 'Azure.DevOps.ServiceConnection'
         # Set JSON ObjectName field to organiztion.project.service connection name
         $serviceConnection | Add-Member -MemberType NoteProperty -Name ObjectName -Value "$Organization.$Project.$($serviceConnection.name)"
+        
         # Get checks for service connection
         $serviceConnectionChecks = @(Get-AzDevOpsServiceConnectionChecks -Project $Project -ServiceConnectionId $serviceConnection.id)
         $serviceConnection | Add-Member -MemberType NoteProperty -Name Checks -Value $serviceConnectionChecks
+        # Set id field to a JSON object with originalId, project and organization
+        $serviceConnection.id = @{
+            originalId = $serviceConnection.id
+            project = $Project
+            organization = $Organization
+        } | ConvertTo-Json -Depth 100
         if ($PassThru) {
             Write-Output $serviceConnection
         } else {

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Tasks.VariableGroups.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Tasks.VariableGroups.ps1
@@ -92,6 +92,7 @@ Function Export-AzDevOpsVariableGroups {
         # Set the id to a JSON object with the originalId, project and organization
         $variableGroup.id = @{
             originalId = $variableGroup.id
+            resourceName = $variableGroup.name
             project = $Project
             organization = $Organization
         } | ConvertTo-Json -Depth 100

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Tasks.VariableGroups.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Tasks.VariableGroups.ps1
@@ -89,6 +89,12 @@ Function Export-AzDevOpsVariableGroups {
         $variableGroup = $_
         $variableGroup | Add-Member -MemberType NoteProperty -Name 'ObjectType' -Value 'Azure.DevOps.Tasks.VariableGroup'
         $variableGroup | Add-Member -MemberType NoteProperty -Name 'ObjectName' -Value "$Organization.$Project.$($variableGroup.name)"
+        # Set the id to a JSON object with the originalId, project and organization
+        $variableGroup.id = @{
+            originalId = $variableGroup.id
+            project = $Project
+            organization = $Organization
+        } | ConvertTo-Json -Depth 100
         $variableGroupName = $variableGroup.name
         if ($PassThru) {
             Write-Output $variableGroup

--- a/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Repos.Rule.ps1
+++ b/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Repos.Rule.ps1
@@ -108,7 +108,7 @@ Rule 'Azure.DevOps.Repos.DefaultBranchPolicyEnforceLinkedWorkItems' `
         Recommend 'Enforce linked work items.'
         # Links 'https://docs.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops#enforce-linked-work-items'
         $Assert.NotNull($TargetObject, "MainBranchPolicy")
-        $Assert.HasField($TargetObject, "MainBranchPolicy[?@type.id == '40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e'].type", $true)
+        $Assert.HasField($TargetObject, "MainBranchPolicy[?@type.id == '40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e'].type", $false)
 }
 
 # Synopsis: The default branch policy should enforce comment resolution


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This adds an `id` property to each exported object which holds a JSON object string containing organization, project, resource name and the original `id` if present. This is done because the `id` property is uploaded to _Log Analytics_ by _PSRule.Monitor_ and the json can then be parsed in KQL for reporting purposes.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fix #99 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
