### PR TITLE
Removed grave accent in order to resolve issue #105

### DIFF
--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
                 Connect-AzDevOps -Organization $(devops_organization) -PAT "$(ADOPAT)"
                 Export-AzDevOpsRuleData `
                   -Project $(devops_project) `
-                  -OutputPath .\Temp `
+                  -OutputPath .\Temp
                 Assert-PSRule -Style AzurePipelines `
                   -Module PSRule.Rules.AzureDevOps `
                   -InputPath '$(Build.SourcesDirectory)/Temp/' `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove grave accent from azure-pipelines.yml in order to resolve issue #105 

## Related Issue
[For Azure DevOps pipeline example "Grave Accent `" symbol should be removed](https://github.com/cloudyspells/PSRule.Rules.AzureDevOps/issues/105)

## Motivation and Context
The grave accent causes Powershell to attempt to execute the cmdlet on line 54 as an extra parameter. Powershell doesn’t do that.

## How Has This Been Tested?
Testing would not be an appropriate use of our time for this particular issue.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
