### PR TITLE
Update DevOps.ServiceConnections.ps1 with fix for issue #106

### DIFF
--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
@@ -153,7 +153,7 @@ function Export-AzDevOpsServiceConnections {
             Write-Output $serviceConnection
         } else {
             Write-Verbose "Exporting service connection $($serviceConnection.name) as file $($serviceConnection.name).ado.sc.json"
-            $serviceConnection | ConvertTo-Json -Depth 100 | Out-File "$OutputPath/$($serviceConnection.name.replace('/'.'')).ado.sc.json"
+            $serviceConnection | ConvertTo-Json -Depth 100 | Out-File "$OutputPath/$($serviceConnection.name.replace('/','')).ado.sc.json"
         }
     }
 }

--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.ServiceConnections.ps1
@@ -153,7 +153,7 @@ function Export-AzDevOpsServiceConnections {
             Write-Output $serviceConnection
         } else {
             Write-Verbose "Exporting service connection $($serviceConnection.name) as file $($serviceConnection.name).ado.sc.json"
-            $serviceConnection | ConvertTo-Json -Depth 100 | Out-File "$OutputPath/$($serviceConnection.name).ado.sc.json"
+            $serviceConnection | ConvertTo-Json -Depth 100 | Out-File "$OutputPath/$($serviceConnection.name.replace('/'.'')).ado.sc.json"
         }
     }
 }


### PR DESCRIPTION
# Utilized "replace" method to remove undue backslashes from the export function's resultant filename.

## Description

Utilized "replace" method to remove undue backslashes from the export function's resultant filename. Changes made will fix issue #106.

## Related Issue

#106

## Motivation and Context

Issue #106 occurs because backslashes are not removed from the service connection name prior to export. This breaks the Out-File cmdlet because the path will always be incorrect..

## How Has This Been Tested?

```powershell
# Define variables
$OutputPath = "C:/temp"
$serviceconnection = @{
    name = "CI/CD template Repo Connection"
    description = "desc is nill in this case"
}

# test string without replace -> will fail
# Result: C:/temp/CI/CD template Repo Connection.ado.sc.json
$filename_no_replace = "$OutputPath/$($serviceConnection.name).ado.sc.json"
Write-Output -InputObject $filename_no_replace

# test string without replace -> will fail
# Result: C:/temp/CICD template Repo Connection.ado.sc.json
$filename_with_replace = "$OutputPath/$($serviceConnection.name.replace('/','')).ado.sc.json"
Write-Output -InputObject $filename_with_replace
```

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
