### PR TITLE
Fix #115 - Export branch stats + last commit rule

### DIFF
--- a/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.Branch.CommitRecent.md
+++ b/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.Branch.CommitRecent.md
@@ -1,0 +1,27 @@
+---
+category: Microsoft Azure DevOps Repos
+severity: Informational
+online version: https://github.com/cloudyspells/PSRule.Rules.AzureDevOps/blob/main/src/PSRule.Rules.AzureDevOps/en/Azure.DevOps.Repos.Branch.CommitRecent.md
+---
+
+# Azure.DevOps.Repos.Branch.CommitRecent
+
+## SYNOPSIS
+
+The branch has not seen recent commits.
+
+## DESCRIPTION
+
+The branch has not seen recent commits. This may indicate that the branch is not being
+actively maintained or that the team's Git workflow is not being followed. Consider if 
+the branch is still needed and if not, remove it. 
+
+Mininum TokenType: `ReadOnly`
+
+## RECOMMENDATION
+
+Consider if the branch is still needed and if not, remove it.
+
+## LINKS
+
+- 

--- a/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Repo.Branches.Rule.ps1
+++ b/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Repo.Branches.Rule.ps1
@@ -122,3 +122,20 @@ Rule 'Azure.DevOps.Repos.Branch.BranchPolicyRequireBuild' `
         # Links 'https://docs.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops'
         $Assert.HasFieldValue(($TargetObject.BranchPolicy | Where-Object { $_.type.id -eq '0609b952-1397-4640-95ec-e00a01b2c241'}), "type.displayName", "Build")
 }
+
+# Synopsis: The branch should have a commit in the last 90 days
+Rule 'Azure.DevOps.Repos.Branch.CommitRecent' `
+    -Ref 'ADO-RB-014' `
+    -Type 'Azure.DevOps.Repo.Branch' `
+    -Tag @{ release = 'GA'} `
+    -Level Warning {
+        # Description: The branch should have a commit in the last 90 days
+        Reason 'The branch does not have a commit in the last 90 days.'
+        Recommend 'Consider merging the branch or deleting it.'
+        # Links: https://learn.microsoft.com/en-us/azure/devops/organizations/security/security-best-practices?view=azure-devops#repositories-and-branches
+        If ([datetime]$TargetObject.Stats.commit.committer.date -ge (Get-Date).AddDays(-($Configuration.GetValueOrDefault('lastCommitDays', 90)))) {
+            $Assert.Pass()
+        } else {
+            $Assert.Fail('The branch does not have a commit in the last 90 days.')
+        }
+}

--- a/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Repos.Rule.ps1
+++ b/src/PSRule.Rules.AzureDevOps/rules/AzureDevOps.Repos.Rule.ps1
@@ -219,3 +219,4 @@ Rule 'Azure.DevOps.Repos.ProjectValidUsers' `
             }
         }
 }
+

--- a/src/PSRule.Rules.AzureDevOps/rules/Baseline.Default.Rule.yaml
+++ b/src/PSRule.Rules.AzureDevOps/rules/Baseline.Default.Rule.yaml
@@ -11,3 +11,4 @@ spec:
     ghasBlockPushesEnabled: true
     branchMinimumApproverCount: 1
     releaseMinimumProductionApproverCount: 1
+    lastCommitDays: 90

--- a/tests/DevOps.Repos.Tests.ps1
+++ b/tests/DevOps.Repos.Tests.ps1
@@ -71,6 +71,20 @@ Describe "Functions: DevOps.Repos.Tests" {
         It " should return a list of branches" {
             $branches | Should -Not -BeNullOrEmpty
         }
+
+        It " should return a list of branches that are of type PSObject" {
+            $branches[0] | Should -BeOfType [PSCustomObject]
+        }
+
+        It " should return a list of branches that have a name" {
+            $branches[0].name | Should -Not -BeNullOrEmpty
+            $branches[0].name | Should -BeOfType [string]
+        }
+
+        It " should return a list of branches that have a commit" {
+            $branches[0].Stats.commit | Should -Not -BeNullOrEmpty
+            $branches[0].Stats.commit | Should -BeOfType [PSCustomObject]
+        }
     }
 
     Context " Get-AzDevOpsBranches with wrong parameters" {

--- a/tests/Rules.Common.Tests.ps1
+++ b/tests/Rules.Common.Tests.ps1
@@ -42,9 +42,9 @@ BeforeAll {
 
 Describe "PSRule.Rules.AzureDevOps Rules" {
     Context ' Base rules' {
-        It ' should contain 76 rules' {
+        It ' should contain 77 rules' {
             $rules = Get-PSRule -Module PSRule.Rules.AzureDevOps
-            $rules.Count | Should -Be 76
+            $rules.Count | Should -Be 77
         }
 
         It ' should contain a markdown help file for each rule' {

--- a/tests/Rules.Repos.Branches.Tests.ps1
+++ b/tests/Rules.Repos.Branches.Tests.ps1
@@ -163,4 +163,18 @@ Describe "Azure.DevOps.Repos.Branch rules" {
             $ruleHits.Count | Should -Be 1;
         }
     }
+
+    # This rule is only checked for hits and not results as it is a pain to maintain at this time
+    # The rule has been tested for results manually and is working as expected
+    Context ' Azure.DevOps.Repos.Branch.CommitRecent' {
+        It ' should hit for targets named fail' {
+            $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.Branch.CommitRecent' -and $_.TargetName -like '*psrule-fail-project.refs/heads/fail-branch' })
+            $ruleHits.Count | Should -Be 1;
+        }
+
+        It ' should hit for targets named success' {
+            $ruleHits = @($ruleResult | Where-Object { $_.RuleName -eq 'Azure.DevOps.Repos.Branch.CommitRecent' -and $_.TargetName -like '*repository-success.refs/heads/main' })
+            $ruleHits.Count | Should -Be 1;
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds branch stats to the branch objects exported by the module. A rule has been added to check for recent commits to branches. The rule is configurable with a `lastCommitDays` setting to configure the number of days before a branch is considered stale.

Added rule: `Azure.DevOps.Repos.Branch.CommitRecent`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fix #115 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Requested by platform engineering team member

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testing + CI test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
