### PR TITLE
Exclude disabled repos by default

### DIFF
--- a/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
+++ b/src/PSRule.Rules.AzureDevOps/Functions/DevOps.Repos.ps1
@@ -17,7 +17,10 @@ Function Get-AzDevOpsRepos {
     param (
         [Parameter(Mandatory)]
         [string]
-        $Project
+        $Project,
+        [Parameter(Mandatory=$false)]
+        [switch]
+        $IncludeDisabled
     )
     if ($null -eq $script:connection) {
         throw "Not connected to Azure DevOps. Run Connect-AzDevOps first"
@@ -37,7 +40,11 @@ Function Get-AzDevOpsRepos {
     catch {
         throw $_.Exception.Message
     }
-    return @($response.value)
+    # If the IncludeDisabled switch is set, return all repos including disabled ones
+    if ($IncludeDisabled -eq $true) {
+        return @($response.value)
+    }
+    return @($response.value | Where-Object { $_.isDisabled -eq $false })
 }
 Export-ModuleMember -Function Get-AzDevOpsRepos
 # End of Function Get-AzDevOpsRepos


### PR DESCRIPTION
This fixes 404 responses when attempting to make requests to disabled repos.

## Description
I added a new switch param as I figured it was best not to always exclude disabled repos from responses. However, the default is to exclude them as I didn't want to affect the rest of the code. I did check to see if AzDO supports OData filters but it doesn't look like that's the case so we have to filter it after the response is received.

## Related Issue
#123 

## Motivation and Context
Currently, if you run the tool on a Project with a disabled repo then it throws an exception.

## How Has This Been Tested?
I ran the `Get-AzDevOpsRepos` cmdlet after making the change and observed that the disabled repo in my project was no longer in the returned array. I ran the tests for `DevOps.Repos.Tests` against my project and got the following:
### Before changes (fc472f34)
```
Tests Passed: 28, Failed: 24, Skipped: 0 NotRun: 0
BeforeAll \ AfterAll failed: 8
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsBranches on an empty repository
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsRepositoryAcls
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsRepositoryAcls with wrong parameters
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsRepositoryAcls with a ReadOnly TokenType
  - Functions: DevOps.Repos.Tests. Test-AzDevOpsFileExists
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsRepositoryPipelinePermissions
  - Functions: DevOps.Repos.Tests. Export-AzDevOpsReposAndBranchPolicies
  - Functions: DevOps.Repos.Tests. Export-AzDevOpsReposAndBranchPolicies -PassThru
```
### After changes
```
Tests Passed: 28, Failed: 24, Skipped: 0 NotRun: 0
BeforeAll \ AfterAll failed: 8
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsBranches on an empty repository
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsRepositoryAcls
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsRepositoryAcls with wrong parameters
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsRepositoryAcls with a ReadOnly TokenType
  - Functions: DevOps.Repos.Tests. Test-AzDevOpsFileExists
  - Functions: DevOps.Repos.Tests. Get-AzDevOpsRepositoryPipelinePermissions
  - Functions: DevOps.Repos.Tests. Export-AzDevOpsReposAndBranchPolicies
  - Functions: DevOps.Repos.Tests. Export-AzDevOpsReposAndBranchPolicies -PassThru
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
